### PR TITLE
Convert rate limiter to pure ASGI so client disconnects propagate

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ import os
 from app.api.v1.router import api_router
 from app.core.config import settings
 from app.core.database import Base, db, init_db
-from app.middleware.rate_limiter import rate_limit_middleware
+from app.middleware.rate_limiter import RateLimiterMiddleware
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -52,8 +52,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Rate limiting on expensive routes (LLM, PDF, auth) — see RATE_LIMITS
-app.middleware("http")(rate_limit_middleware)
+# Rate limiting on expensive routes (LLM, PDF, auth) — see RATE_LIMITS.
+# Pure ASGI so client disconnects reach endpoints; added after CORSMiddleware
+# to keep it outermost (add_middleware is LIFO), matching the previous
+# @app.middleware("http") position in the stack.
+app.add_middleware(RateLimiterMiddleware)
 
 # Include API routes
 app.include_router(api_router, prefix="/api/v1")

--- a/app/middleware/__init__.py
+++ b/app/middleware/__init__.py
@@ -1,5 +1,5 @@
 """Middleware package"""
 from .rate_limit_config import get_token_limit
-from .rate_limiter import rate_limiter, rate_limit_middleware
+from .rate_limiter import rate_limiter, RateLimiterMiddleware
 
-__all__ = ["rate_limiter", "rate_limit_middleware", "get_token_limit"]
+__all__ = ["rate_limiter", "RateLimiterMiddleware", "get_token_limit"]

--- a/app/middleware/rate_limiter.py
+++ b/app/middleware/rate_limiter.py
@@ -5,6 +5,11 @@ Only paths listed in RATE_LIMITS are enforced (all static). Storage is
 in-memory per process unless Redis is configured — with 2 uvicorn workers
 the effective limit is up to 2x the configured value, acceptable for MVP.
 RATE_LIMIT_ENABLED=false disables enforcement (used by the test suite).
+
+Implemented as pure ASGI middleware (not BaseHTTPMiddleware): the original
+receive channel is passed through untouched so downstream
+request.is_disconnected() sees real http.disconnect events, letting the
+process-motion abort hook stop paid LLM calls when the client goes away.
 """
 from typing import Optional
 from datetime import datetime, timedelta
@@ -13,6 +18,7 @@ from collections import defaultdict
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from slowapi.util import get_remote_address
+from starlette.types import ASGIApp, Receive, Scope, Send
 import logging
 import os
 
@@ -31,7 +37,7 @@ else:
 logger = logging.getLogger(__name__)
 
 
-class RateLimiterMiddleware(UsageQuotaMixin):
+class RateLimiter(UsageQuotaMixin):
     """Rate limiting with token quotas and cost control"""
 
     def __init__(
@@ -168,25 +174,40 @@ class RateLimiterMiddleware(UsageQuotaMixin):
         return True, 0
 
 
-# Create middleware instance
-rate_limiter = RateLimiterMiddleware()
+# Create shared limiter instance
+rate_limiter = RateLimiter()
 
 
-async def rate_limit_middleware(request: Request, call_next):
-    """FastAPI middleware enforcing RATE_LIMITS on expensive routes"""
-    enabled = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
-    if not enabled or request.url.path not in RATE_LIMITS:
-        return await call_next(request)
+class RateLimiterMiddleware:
+    """Pure ASGI middleware enforcing RATE_LIMITS on expensive routes"""
 
-    allowed, retry_after = await rate_limiter.check_rate_limit(request, request.url.path)
-    if not allowed:
-        return JSONResponse(
-            status_code=429,
-            content={
-                "error": "Rate limit exceeded",
-                "message": "Too many requests. Please try again later."
-            },
-            headers={"Retry-After": str(retry_after)}
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        enabled = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
+        path = scope["path"]
+        if not enabled or path not in RATE_LIMITS:
+            await self.app(scope, receive, send)
+            return
+
+        allowed, retry_after = await rate_limiter.check_rate_limit(
+            Request(scope), path
         )
+        if not allowed:
+            response = JSONResponse(
+                status_code=429,
+                content={
+                    "error": "Rate limit exceeded",
+                    "message": "Too many requests. Please try again later."
+                },
+                headers={"Retry-After": str(retry_after)}
+            )
+            await response(scope, receive, send)
+            return
 
-    return await call_next(request)
+        await self.app(scope, receive, send)

--- a/app/middleware/usage_quotas.py
+++ b/app/middleware/usage_quotas.py
@@ -1,5 +1,5 @@
 """
-Per-user token/request quota tracking (mixin for RateLimiterMiddleware).
+Per-user token/request quota tracking (mixin for RateLimiter).
 
 Currently unconsumed by any route — kept for the planned quota rollout.
 """

--- a/tasks/real-llm-browser-test-results.md
+++ b/tasks/real-llm-browser-test-results.md
@@ -322,10 +322,12 @@ vanished for every user with children. Both fixed TDD-first; the tests now call 
 the real condition evaluator, closing the always-true-stub gap that let it ship.
 
 **Honest gaps / deferred (tracked):**
-- **L18 is inert in production**: live check proved a real client disconnect does NOT
-  propagate through the BaseHTTPMiddleware rate limiter to `request.is_disconnected()` —
-  the abort hook + tests are in place but won't fire until the rate limiter becomes pure
-  ASGI middleware (deferred ticket).
+- **L18 — RESOLVED 2026-07-11**: rate limiter converted to pure ASGI middleware
+  (branch fix/asgi-rate-limiter, commit 481c0ae; 522 backend tests). Live re-check:
+  curl-aborted client at 2s → LLM section loop stopped after **1 call (was 3)** —
+  disconnects now propagate and abandoned runs stop burning tokens. Noted pre-existing:
+  429s sit outside CORS (cross-origin browsers can't read Retry-After) and Redis mode
+  is dead code — both unchanged.
 - Possible third regression manifestation on *resume*: drafts store raw submit data, so
   `resumeAnswers` (useMotionInit merge) could re-poison conditions in a resumed session —
   flagged, not yet reproduced.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -326,10 +326,11 @@ Backend 520 passed/3 xfailed (+122), frontend 252 passed/36 suites (+44), build 
 - Verification caught what suites couldn't: the C3 reorder regressed cross-step conditional
   questions (blank re-registration shadowing/poisoning allAnswers) — fixed in 29f2da8 +
   2084eb5 with the evaluator-stub test gap closed.
-- Deferred (tracked in report addendum): rate limiter → pure ASGI (disconnect abort inert
-  behind BaseHTTPMiddleware — verified live), resumeAnswers re-poisoning on resume,
+- Deferred (tracked in report addendum): resumeAnswers re-poisoning on resume,
   party-block templating, structured-JSON gameplan, ex-parte alias, progress staging,
-  Dashboard badge key.
+  Dashboard badge key. RESOLVED same day: rate limiter → pure ASGI (fix/asgi-rate-limiter,
+  481c0ae) — live re-check shows the LLM loop stops after 1 section call on client
+  disconnect (was 3); PR #5 (all L1-L19 work) merged to main.
 
 ### Rename to Family Court Helper (DONE 2026-07-10)
 User's final call after 3-round naming exercise (Camino was recommended runner-up;

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -3,8 +3,12 @@ Rate limits must actually be enforced on expensive routes (LLM, PDF, auth).
 """
 import pytest
 from httpx import AsyncClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
 
-from app.middleware.rate_limiter import rate_limiter
+from app.main import app
+from app.middleware.rate_limiter import RateLimiterMiddleware, rate_limiter
 
 pytestmark = pytest.mark.asyncio
 
@@ -76,6 +80,43 @@ async def test_unlisted_paths_are_not_throttled(client: AsyncClient, rate_limits
     for _ in range(30):
         resp = await client.get("/health")
         assert resp.status_code == 200
+
+
+async def test_rate_limiter_registered_as_pure_asgi_middleware():
+    # BaseHTTPMiddleware wraps the receive channel so http.disconnect never
+    # reaches endpoints — the limiter must sit in the stack as a raw ASGI class
+    stack_classes = [m.cls for m in app.user_middleware]
+    assert RateLimiterMiddleware in stack_classes
+    assert BaseHTTPMiddleware not in stack_classes
+
+
+async def test_disconnect_reaches_downstream_through_middleware():
+    # The original receive must pass through untouched so a downstream
+    # request.is_disconnected() sees the real http.disconnect event
+    seen = {}
+
+    async def inner_app(scope, receive, send):
+        seen["disconnected"] = await Request(scope, receive).is_disconnected()
+        await PlainTextResponse("ok")(scope, receive, send)
+
+    events = [{"type": "http.disconnect"}]
+
+    async def receive():
+        return events.pop(0)
+
+    async def send(message):
+        pass
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/health",  # unlisted path — middleware passes through
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+    }
+    await RateLimiterMiddleware(inner_app)(scope, receive, send)
+
+    assert seen["disconnected"] is True
 
 
 async def test_kill_switch_disables_limits(


### PR DESCRIPTION
Follow-up to #5. The rate limiter was Starlette BaseHTTPMiddleware, which wraps the receive channel so `http.disconnect` never reached endpoints — the LLM-abort hook from #5 (c1d1137) was inert. Converted to a pure ASGI middleware class preserving the full contract (429 + Retry-After, per-route limits, RATE_LIMIT_ENABLED kill switch; all pre-existing rate-limit tests pass unmodified; 522 backend tests).

**Live verification**: mock-LLM server with 3s/section delay, client aborted at 2s via `curl --max-time 2` → the 3-section loop stopped after **1 call** (pre-change control: all 3 ran). Abandoned motion-processing requests no longer burn paid Claude calls.

Pre-existing, unchanged (noted for later): 429s sit outside CORSMiddleware (cross-origin browsers can't read Retry-After); Redis mode is dead code (init_redis never called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)