### PR TITLE
Opus 4.8 drafting tier + LLM semantic refute-pass

### DIFF
--- a/app/api/v1/endpoints/llm.py
+++ b/app/api/v1/endpoints/llm.py
@@ -14,6 +14,7 @@ from app.models.motion import Motion, MotionDraft
 from app.models.profile import Profile
 from app.api.v1.endpoints.auth import get_current_user
 from app.core.database import get_db
+from app.services import semantic_check_service
 from app.services.fact_gate import GateContext, run_fact_gate
 from app.services.llm_service import llm_service
 
@@ -184,6 +185,7 @@ async def process_complete_motion(
         # Gate each rewritten section against user-entered facts, then save
         gate_ctx = _gate_context(motion, drafts, profile_data)
         corrections: List[Dict[str, Any]] = []
+        gated_texts: List[str] = []
         errors = []
         sections_processed = 0
 
@@ -195,6 +197,7 @@ async def process_complete_motion(
                         gate_ctx.section_name = section.get("section") or ""
                         gated = run_fact_gate(section.get("rewritten_text"), gate_ctx)
                         draft.llm_output = gated.text
+                        gated_texts.append(gated.text)
                         corrections.extend(c.as_dict() for c in gated.corrections)
                         draft.llm_model = result.get("model")
                         draft.llm_tokens_used = section.get("tokens_used", 0)
@@ -203,6 +206,14 @@ async def process_complete_motion(
                         break
             else:
                 errors.append(f"Section {section.get('section')}: {section.get('error')}")
+
+        # One semantic refute-pass over the whole gated motion (flag-only, fail-open)
+        if gated_texts:
+            corrections.extend(
+                await semantic_check_service.check_text(
+                    "\n\n".join(gated_texts), gate_ctx.intake_values, profile_data
+                )
+            )
 
         motion.fact_check = {"version": 1, "corrections": corrections}
 

--- a/app/api/v1/endpoints/llm.py
+++ b/app/api/v1/endpoints/llm.py
@@ -15,7 +15,7 @@ from app.models.profile import Profile
 from app.api.v1.endpoints.auth import get_current_user
 from app.core.database import get_db
 from app.services import semantic_check_service
-from app.services.fact_gate import GateContext, run_fact_gate
+from app.services.fact_gate import GateContext, merge_intake_values, run_fact_gate
 from app.services.llm_service import llm_service
 
 router = APIRouter()
@@ -48,10 +48,8 @@ class ProcessMotionResponse(BaseModel):
 
 def _gate_context(motion: Motion, drafts, profile_data: Dict[str, Any]) -> GateContext:
     """One ground-truth context for gating every section (findings L1-L4, L7)."""
-    intake_values: Dict[str, Any] = {}
-    for draft in drafts:
-        if isinstance(draft.question_data, dict):
-            intake_values.update(draft.question_data)
+    # Blank re-registrations from later steps must not erase earlier answers
+    intake_values = merge_intake_values([draft.question_data for draft in drafts])
     motion_type = (
         motion.motion_type.value
         if hasattr(motion.motion_type, "value")

--- a/app/api/v1/endpoints/violations.py
+++ b/app/api/v1/endpoints/violations.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel, Field
 
 from app.core.database import get_db
+from app.services import semantic_check_service
 from app.services.fact_gate import GateContext, run_fact_gate
 from app.services.violation_intake_steps import build_wizard_steps
 from app.services.violation_service import ViolationFilingService
@@ -128,6 +129,13 @@ async def process_violation_filing(
         )
         result["declaration"] = gated.text
         result["corrections"] = [c.as_dict() for c in gated.corrections]
+
+        # One semantic refute-pass over the gated declaration (flag-only, fail-open)
+        result["corrections"].extend(
+            await semantic_check_service.check_text(
+                gated.text, intake_data.dict(), profile_data or {}
+            )
+        )
 
         # Save to database as a motion
         motion = Motion(

--- a/app/services/claude_llm_service.py
+++ b/app/services/claude_llm_service.py
@@ -32,6 +32,8 @@ OPERATION_MODELS = {
     "screenshot_reading": CHAT_MODEL,
     # Verbatim reproduction fidelity matters for citations — use the drafting tier
     "claim_citation": DRAFTING_MODEL,
+    # Adversarial refute-pass over drafted motions — needs drafting-tier judgment
+    "semantic_check": DRAFTING_MODEL,
 }
 
 # Mirrors the per-operation output limits used by the Vertex backend
@@ -48,6 +50,7 @@ OPERATION_MAX_TOKENS = {
     "conversation_threading": 6000,
     "screenshot_reading": 6000,
     "claim_citation": 6000,
+    "semantic_check": 1500,
 }
 
 # PRD compliance section C3: the line between legal information (allowed)

--- a/app/services/claude_llm_service.py
+++ b/app/services/claude_llm_service.py
@@ -3,7 +3,7 @@ Claude backend for LLM operations (M2).
 
 Routes operations to the right model tier:
 - claude-haiku-4-5: chat, intent classification, UPL checks (high volume, low cost)
-- claude-sonnet-4-6: declaration/motion drafting (quality-sensitive legal writing)
+- claude-opus-4-8: declaration/motion drafting (quality-sensitive legal writing)
 
 The stable system prompt (base prompt + UPL guardrails) is cached via
 prompt caching; per-request content goes in the user message.
@@ -16,7 +16,7 @@ from typing import List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 CHAT_MODEL = os.getenv("CLAUDE_CHAT_MODEL", "claude-haiku-4-5")
-DRAFTING_MODEL = os.getenv("CLAUDE_DRAFTING_MODEL", "claude-sonnet-4-6")
+DRAFTING_MODEL = os.getenv("CLAUDE_DRAFTING_MODEL", "claude-opus-4-8")
 
 OPERATION_MODELS = {
     "chat_response": CHAT_MODEL,

--- a/app/services/fact_gate/__init__.py
+++ b/app/services/fact_gate/__init__.py
@@ -5,6 +5,17 @@ text before it can reach a court PDF (real-LLM findings L1-L4, L7, L8, L15).
 Pure stdlib; no imports from other app services.
 """
 from app.services.fact_gate.gate import run_fact_gate
-from app.services.fact_gate.types import Correction, GateContext, GateResult
+from app.services.fact_gate.types import (
+    Correction,
+    GateContext,
+    GateResult,
+    merge_intake_values,
+)
 
-__all__ = ["run_fact_gate", "Correction", "GateContext", "GateResult"]
+__all__ = [
+    "run_fact_gate",
+    "Correction",
+    "GateContext",
+    "GateResult",
+    "merge_intake_values",
+]

--- a/app/services/fact_gate/types.py
+++ b/app/services/fact_gate/types.py
@@ -73,6 +73,38 @@ def excerpt(text: str, limit: int = EXCERPT_LIMIT) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
+def _is_blank(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def merge_intake_values(dicts: List[Any]) -> Dict[str, Any]:
+    """Merge per-step intake dicts in order, ignoring blank re-registrations.
+
+    The intake wizard saves each step with the raw form store, so later steps
+    re-register earlier fields as None/""/all-false (871cafa family). Blanks
+    never overwrite real answers; checkbox groups union their truthy leaves;
+    a genuine non-blank re-answer on a later step still wins.
+    """
+    merged: Dict[str, Any] = {}
+    for data in dicts:
+        if not isinstance(data, dict):
+            continue
+        for key, value in data.items():
+            if _is_blank(value):
+                continue
+            if isinstance(value, dict):
+                truthy = {k: v for k, v in value.items() if v}
+                if not truthy:
+                    continue
+                existing = merged.get(key)
+                merged[key] = (
+                    {**existing, **truthy} if isinstance(existing, dict) else truthy
+                )
+                continue
+            merged[key] = value
+    return merged
+
+
 def iter_scalars(value: Any, key: str = "") -> Iterator[Tuple[str, Any]]:
     """Yield (key, scalar) pairs from arbitrarily nested intake structures."""
     if isinstance(value, dict):

--- a/app/services/semantic_check_service.py
+++ b/app/services/semantic_check_service.py
@@ -1,0 +1,117 @@
+"""
+LLM semantic refute-pass over generated motion text.
+
+Complements the deterministic fact gate (app/services/fact_gate): the gate's
+regexes catch mechanical fabrications (names, dates, amounts, authorities);
+this pass asks the drafting-tier model to refute semantic embellishments the
+regexes cannot see. Flag-only — it never edits text — and fail-open: any
+error or timeout returns [] so motion processing is never blocked.
+"""
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+from app.services.fact_gate.types import iter_scalars
+from app.services.llm_json import parse_llm_json
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT_SECONDS = 20.0
+MAX_FINDINGS = 10
+CLAIM_LIMIT = 120
+
+_INSTRUCTIONS = (
+    "You are a skeptical reviewer. Try to REFUTE this document: list every "
+    "factual claim (name, date, amount, event, frequency/quantity) that is "
+    "NOT supported by the intake data above, and any sentence that recommends "
+    "a course of action (legal advice). Do NOT rewrite anything. Return "
+    'STRICT JSON: {"findings": [{"claim": "<verbatim excerpt ≤120 chars>", '
+    '"reason": "<one plain-English sentence>"}]} — empty findings array if '
+    "nothing to flag."
+)
+
+
+async def check_text(
+    generated_text: str,
+    intake_values: Dict[str, Any],
+    context: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Adversarial review of generated text; correction dicts, [] on any failure."""
+    try:
+        return await asyncio.wait_for(
+            _run_check(generated_text, intake_values, context),
+            timeout=TIMEOUT_SECONDS,
+        )
+    except Exception as exc:  # fail-open: the checker must never block processing
+        logger.warning("Semantic check skipped: %s", exc)
+        return []
+
+
+async def _run_check(
+    generated_text: str,
+    intake_values: Dict[str, Any],
+    context: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    # Resolved at call time, not import time: test_e2e_regressions reloads
+    # app.services.llm_service mid-suite, so a bound import could go stale.
+    from app.services import llm_service as llm
+
+    if llm.USE_MOCK_LLM or llm.llm_service.claude_backend is None:
+        return []  # honest no-op — never fabricate review results
+    prompt = _build_prompt(generated_text, intake_values, context)
+    raw, _tokens, _model = await llm.llm_service.claude_backend.generate(
+        prompt, "semantic_check"
+    )
+    return _to_corrections(parse_llm_json(raw))
+
+
+def _build_prompt(
+    generated_text: str,
+    intake_values: Dict[str, Any],
+    context: Dict[str, Any],
+) -> str:
+    lines = [
+        f"{key}: {value}"
+        for source in (context or {}, intake_values or {})
+        for key, value in iter_scalars(source)
+        if key
+    ]
+    facts = "\n".join(lines) or "(none provided)"
+    return (
+        "INTAKE DATA (the only permitted source of facts):\n"
+        f"{facts}\n\n"
+        "GENERATED DOCUMENT:\n"
+        f"{generated_text}\n\n"
+        f"{_INSTRUCTIONS}"
+    )
+
+
+def _to_corrections(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Validate the findings payload and map it to fact-check correction dicts."""
+    findings = data.get("findings")
+    if not isinstance(findings, list):
+        return []
+    corrections: List[Dict[str, Any]] = []
+    for finding in findings[:MAX_FINDINGS]:
+        if not isinstance(finding, dict):
+            continue
+        claim, reason = finding.get("claim"), finding.get("reason")
+        if not isinstance(claim, str) or not isinstance(reason, str):
+            continue
+        claim, reason = claim.strip()[:CLAIM_LIMIT], reason.strip()
+        if not claim or not reason:
+            continue
+        corrections.append(
+            {
+                "type": "semantic_flag",
+                "severity": "needs_review",
+                "section": "reviewer",
+                "original": claim,
+                "replacement": None,
+                "message": (
+                    f"Our automated reviewer flagged: {reason} — "
+                    f'verify "{claim}" against your records before filing.'
+                ),
+            }
+        )
+    return corrections

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,20 @@
 # Build Plan — Family Court Helper MVP (formerly California Motion Writer)
 
+## Model upgrade + LLM checker (2026-07-14, approved: Opus drafter + Opus checker, no Gemini)
+- [x] U1 feat(llm): drafting tier Sonnet 4.6 → Opus 4.8 (1ff81b6) — live-verified, drafts
+      carry claude-opus-4-8, ~54s per motion (comparable to Sonnet)
+- [x] U2 feat(llm): Opus semantic refute-pass (8e231b8) — one flag-only call per motion,
+      findings render in the existing corrections banner, fail-open. Haiku stays on utility.
+- [x] U3 Verified live twice. Run 1 exposed a REAL pre-existing bug the checker caught:
+      blank draft values poisoned the backend intake merge → the gate was stripping GENUINE
+      user facts ($3,200/$85/June 14) as unverifiable. Fixed in 9a83606 (merge_intake_values
+      ignores blank overwrites; verbatim live DB shapes as fixtures). Run 2: all real facts
+      survive in the PDF, checker flags now catch a real drafting quality issue (Opus writes
+      [TO BE COMPLETED] for provided case number/county). Backend 544 passed / 3 xfailed.
+      Follow-ups: dedup near-identical checker findings; extend gate placeholder-fill to
+      case_number/county; frontend per-step-only saveDraft payloads (upstream fix for the
+      draft-poisoning family).
+
 Source: PRD_COMPLETE.md + approved plan (Phase A-F).
 Build strategy: orchestrator (this session) + Sonnet subagents for implementation, Haiku for mechanical tasks.
 

--- a/tests/test_claude_llm_service.py
+++ b/tests/test_claude_llm_service.py
@@ -52,6 +52,10 @@ class TestOperationRouting:
         assert OPERATION_MAX_TOKENS["conversation_threading"] == 6000
         assert OPERATION_MAX_TOKENS["claim_citation"] == 6000
 
+    def test_semantic_check_uses_drafting_tier(self):
+        assert OPERATION_MODELS["semantic_check"] == DRAFTING_MODEL
+        assert OPERATION_MAX_TOKENS["semantic_check"] == 1500
+
     def test_default_model_ids(self):
         assert DRAFTING_MODEL == "claude-opus-4-8"
         assert CHAT_MODEL == "claude-haiku-4-5"

--- a/tests/test_claude_llm_service.py
+++ b/tests/test_claude_llm_service.py
@@ -36,7 +36,7 @@ def _service_with_mock_client(text="Generated text"):
 
 
 class TestOperationRouting:
-    def test_drafting_operations_use_sonnet(self):
+    def test_drafting_operations_use_drafting_tier(self):
         for op in ("section_rewrite", "declaration", "best_interests", "complete_motion"):
             assert OPERATION_MODELS[op] == DRAFTING_MODEL
 
@@ -53,7 +53,7 @@ class TestOperationRouting:
         assert OPERATION_MAX_TOKENS["claim_citation"] == 6000
 
     def test_default_model_ids(self):
-        assert DRAFTING_MODEL == "claude-sonnet-4-6"
+        assert DRAFTING_MODEL == "claude-opus-4-8"
         assert CHAT_MODEL == "claude-haiku-4-5"
 
     def test_max_tokens_match_existing_operation_limits(self):

--- a/tests/test_fact_gate_merge.py
+++ b/tests/test_fact_gate_merge.py
@@ -1,0 +1,74 @@
+"""
+merge_intake_values must ignore the blank re-registered fields that later
+wizard steps save over earlier real answers (871cafa regression family;
+confirmed live in browser-test3.db on 2026-07-11: blanks poisoned the gate's
+intake merge, false-positiving on genuine facts).
+"""
+from app.services.fact_gate.types import merge_intake_values
+
+# Verbatim per-step question_data shapes stored by the live run
+STEP_2 = {"order_types": {"custody": True, "visitation": True, "support": False}}
+STEP_3 = {"order_types": {"custody": False, "visitation": False, "support": False}}
+STEP_4 = {"has_children": None, "current_custody": "", "monthly_income": "3200"}
+STEP_5 = {
+    "monthly_income": "",
+    "facts_summary": "On June 14, 2026 Respondent kept the children overnight.",
+}
+STEP_6 = {"facts_summary": ""}
+
+
+def test_live_run_shapes_keep_the_real_answers():
+    merged = merge_intake_values([STEP_2, STEP_3, STEP_4, STEP_5, STEP_6])
+    assert merged["order_types"] == {"custody": True, "visitation": True}
+    assert merged["monthly_income"] == "3200"
+    assert merged["facts_summary"] == STEP_5["facts_summary"]
+    # blank-only fields never make it into the ground truth
+    assert "has_children" not in merged
+    assert "current_custody" not in merged
+
+
+def test_blank_values_are_skipped():
+    merged = merge_intake_values(
+        [{"a": "real"}, {"a": ""}, {"a": None}, {"a": "   "}, {"b": None}]
+    )
+    assert merged == {"a": "real"}
+
+
+def test_genuine_reanswer_on_a_later_step_still_wins():
+    merged = merge_intake_values(
+        [{"monthly_income": "3200"}, {"monthly_income": "3500"}]
+    )
+    assert merged == {"monthly_income": "3500"}
+
+
+def test_checkbox_groups_union_their_truthy_leaves():
+    merged = merge_intake_values(
+        [
+            {"order_types": {"custody": True, "support": False}},
+            {"order_types": {"visitation": True, "custody": False}},
+        ]
+    )
+    assert merged["order_types"] == {"custody": True, "visitation": True}
+
+
+def test_all_false_group_does_not_erase_an_earlier_group():
+    merged = merge_intake_values([STEP_2, STEP_3])
+    assert merged["order_types"] == {"custody": True, "visitation": True}
+
+
+def test_all_false_group_with_no_earlier_group_is_omitted():
+    merged = merge_intake_values([STEP_3])
+    assert merged == {}
+
+
+def test_non_dict_entries_are_ignored():
+    merged = merge_intake_values([None, "junk", {"a": 1}])
+    assert merged == {"a": 1}
+
+
+def test_inputs_are_not_mutated():
+    earlier = {"order_types": {"custody": True, "support": False}}
+    later = {"order_types": {"visitation": True}}
+    merge_intake_values([earlier, later])
+    assert earlier == {"order_types": {"custody": True, "support": False}}
+    assert later == {"order_types": {"visitation": True}}

--- a/tests/test_llm_gate_integration.py
+++ b/tests/test_llm_gate_integration.py
@@ -194,3 +194,56 @@ async def test_clean_text_is_untouched_with_empty_report(
     detail = await _get_detail(client, auth_headers, motion_id)
     assert detail["drafts"][0]["llm_output"] == CLEAN_TEXT
     assert detail["fact_check"] == {"version": 1, "corrections": []}
+
+
+SEMANTIC_FLAG = {
+    "type": "semantic_flag",
+    "severity": "needs_review",
+    "section": "reviewer",
+    "original": "the parties' work schedules",
+    "replacement": None,
+    "message": (
+        "Our automated reviewer flagged: The intake data does not mention work "
+        "schedules. — verify \"the parties' work schedules\" against your "
+        "records before filing."
+    ),
+}
+
+
+async def test_semantic_flags_append_to_report_and_response(
+    client: AsyncClient, auth_headers: dict, monkeypatch
+):
+    motion_id = await _create_motion_with_drafts(
+        client,
+        auth_headers,
+        [
+            (1, "facts", {"facts": "The schedule needs adjusting."}),
+            (2, "relief_requested", {"relief": "Please adjust the schedule."}),
+        ],
+    )
+    monkeypatch.setattr(
+        llm_endpoint.llm_service,
+        "process_complete_motion",
+        AsyncMock(
+            return_value=_llm_result(
+                [(1, "facts", CLEAN_TEXT), (2, "relief_requested", CLEAN_TEXT)]
+            )
+        ),
+    )
+    check_text = AsyncMock(return_value=[dict(SEMANTIC_FLAG)])
+    monkeypatch.setattr(llm_endpoint.semantic_check_service, "check_text", check_text)
+
+    resp = await client.post(
+        "/api/v1/llm/process-motion", json={"motion_id": motion_id}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    # Clean text produces no gate corrections; the reviewer flag is appended
+    assert resp.json()["corrections"] == [SEMANTIC_FLAG]
+
+    # ONE reviewer call per motion, over the concatenated gated sections
+    check_text.assert_awaited_once()
+    merged_text = check_text.await_args.args[0]
+    assert merged_text.count(CLEAN_TEXT) == 2
+
+    detail = await _get_detail(client, auth_headers, motion_id)
+    assert detail["fact_check"] == {"version": 1, "corrections": [SEMANTIC_FLAG]}

--- a/tests/test_llm_gate_integration.py
+++ b/tests/test_llm_gate_integration.py
@@ -196,6 +196,51 @@ async def test_clean_text_is_untouched_with_empty_report(
     assert detail["fact_check"] == {"version": 1, "corrections": []}
 
 
+# Verbatim per-step question_data shapes from the 2026-07-11 live run
+# (browser-test3.db): the wizard saves each step with the raw form store, so
+# later steps re-register earlier fields as blank/all-false (871cafa family).
+LIVE_RUN_DRAFTS = [
+    (2, "order_types", {"order_types": {"custody": True, "visitation": True, "support": False}}),
+    (3, "children", {"order_types": {"custody": False, "visitation": False, "support": False}}),
+    (4, "income", {"has_children": None, "current_custody": "", "monthly_income": "3200"}),
+    (5, "facts", {
+        "monthly_income": "",
+        "facts_summary": "On June 14, 2026 Respondent kept the children overnight.",
+    }),
+    (6, "review", {"facts_summary": ""}),
+]
+
+REAL_FACTS_TEXT = (
+    "Petitioner's monthly income is $3,200. On June 14, 2026, Respondent "
+    "kept the children overnight without notice."
+)
+
+
+async def test_blank_later_drafts_do_not_poison_the_intake_merge(
+    client: AsyncClient, auth_headers: dict, monkeypatch
+):
+    """Blanked re-registrations must not make the gate false-positive on real facts."""
+    motion_id = await _create_motion_with_drafts(client, auth_headers, LIVE_RUN_DRAFTS)
+    monkeypatch.setattr(
+        llm_endpoint.llm_service,
+        "process_complete_motion",
+        AsyncMock(return_value=_llm_result([(5, "facts", REAL_FACTS_TEXT)])),
+    )
+
+    resp = await client.post(
+        "/api/v1/llm/process-motion", json={"motion_id": motion_id}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    detail = await _get_detail(client, auth_headers, motion_id)
+    outputs = {d["step_number"]: d["llm_output"] for d in detail["drafts"]}
+    facts_output = outputs[5]
+    # The user genuinely entered these on steps 4/5 — the gate must keep them
+    assert "$3,200" in facts_output
+    assert "June 14, 2026" in facts_output
+    assert "[TO BE COMPLETED]" not in facts_output
+
+
 SEMANTIC_FLAG = {
     "type": "semantic_flag",
     "severity": "needs_review",

--- a/tests/test_semantic_check.py
+++ b/tests/test_semantic_check.py
@@ -1,0 +1,151 @@
+"""
+Unit tests for the LLM semantic refute-pass (app/services/semantic_check_service).
+
+The checker is flag-only and fail-open: malformed output, backend errors, and
+timeouts must all yield [] so motion processing is never blocked.
+"""
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import llm_service as llm_module
+from app.services import semantic_check_service
+
+pytestmark = pytest.mark.asyncio
+
+INTAKE = {
+    "violationDescription": "Respondent denied the visit.",
+    "violationDates": ["2026-06-20"],
+}
+CONTEXT = {"party_name": "Rosa Martinez", "county": "San Diego"}
+TEXT = "Respondent has denied visits on at least twelve occasions."
+
+
+def _findings_json(findings) -> str:
+    return json.dumps({"findings": findings})
+
+
+def _real_backend(monkeypatch, raw_response: str) -> AsyncMock:
+    """Point the singleton at a fake Claude backend with mock mode off."""
+    monkeypatch.setattr(llm_module, "USE_MOCK_LLM", False)
+    backend = AsyncMock()
+    backend.generate.return_value = (raw_response, 100, "claude-opus-4-8")
+    monkeypatch.setattr(llm_module.llm_service, "claude_backend", backend)
+    return backend
+
+
+async def test_maps_findings_to_needs_review_corrections(monkeypatch):
+    backend = _real_backend(
+        monkeypatch,
+        _findings_json(
+            [
+                {
+                    "claim": "at least twelve occasions",
+                    "reason": "The intake data does not say how many visits were denied.",
+                }
+            ]
+        ),
+    )
+
+    corrections = await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT)
+
+    assert corrections == [
+        {
+            "type": "semantic_flag",
+            "severity": "needs_review",
+            "section": "reviewer",
+            "original": "at least twelve occasions",
+            "replacement": None,
+            "message": (
+                "Our automated reviewer flagged: The intake data does not say "
+                "how many visits were denied. — verify "
+                '"at least twelve occasions" against your records before filing.'
+            ),
+        }
+    ]
+    backend.generate.assert_awaited_once()
+    prompt, operation = backend.generate.await_args.args
+    assert operation == "semantic_check"
+    assert TEXT in prompt
+    assert "REFUTE" in prompt
+    # Intake and profile context are presented as key: value scalar lines
+    assert "party_name: Rosa Martinez" in prompt
+    assert "violationDescription: Respondent denied the visit." in prompt
+    assert "violationDates: 2026-06-20" in prompt
+
+
+async def test_long_claims_truncated_to_120_chars(monkeypatch):
+    _real_backend(
+        monkeypatch, _findings_json([{"claim": "x" * 200, "reason": "Not supported."}])
+    )
+    corrections = await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT)
+    assert len(corrections) == 1
+    assert corrections[0]["original"] == "x" * 120
+
+
+async def test_findings_capped_at_ten(monkeypatch):
+    findings = [{"claim": f"claim {i}", "reason": f"reason {i}"} for i in range(15)]
+    _real_backend(monkeypatch, _findings_json(findings))
+    corrections = await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT)
+    assert len(corrections) == 10
+
+
+async def test_malformed_json_returns_empty(monkeypatch):
+    _real_backend(monkeypatch, "The document looks mostly fine to me.")
+    assert await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT) == []
+
+
+async def test_invalid_finding_shapes_are_skipped(monkeypatch):
+    _real_backend(
+        monkeypatch,
+        _findings_json(
+            [
+                "not a dict",
+                {"claim": 42, "reason": "wrongly typed claim"},
+                {"claim": "   ", "reason": "blank claim"},
+                {"claim": "missing reason"},
+                {"claim": "real claim", "reason": "real reason"},
+            ]
+        ),
+    )
+    corrections = await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT)
+    assert [c["original"] for c in corrections] == ["real claim"]
+
+
+async def test_findings_not_a_list_returns_empty(monkeypatch):
+    _real_backend(monkeypatch, json.dumps({"findings": {"claim": "x", "reason": "y"}}))
+    assert await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT) == []
+
+
+async def test_generate_error_fails_open(monkeypatch):
+    backend = _real_backend(monkeypatch, "unused")
+    backend.generate.side_effect = RuntimeError("api down")
+    assert await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT) == []
+
+
+async def test_timeout_fails_open(monkeypatch):
+    backend = _real_backend(monkeypatch, "unused")
+
+    async def slow_generate(prompt, operation, user_id=None):
+        await asyncio.sleep(5)
+        return ("{}", 0, "claude-opus-4-8")
+
+    backend.generate = slow_generate
+    monkeypatch.setattr(semantic_check_service, "TIMEOUT_SECONDS", 0.01)
+    assert await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT) == []
+
+
+async def test_mock_llm_mode_is_honest_noop(monkeypatch):
+    monkeypatch.setattr(llm_module, "USE_MOCK_LLM", True)
+    backend = AsyncMock()
+    monkeypatch.setattr(llm_module.llm_service, "claude_backend", backend)
+    assert await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT) == []
+    backend.generate.assert_not_awaited()
+
+
+async def test_no_claude_backend_returns_empty(monkeypatch):
+    monkeypatch.setattr(llm_module, "USE_MOCK_LLM", False)
+    monkeypatch.setattr(llm_module.llm_service, "claude_backend", None)
+    assert await semantic_check_service.check_text(TEXT, INTAKE, CONTEXT) == []

--- a/tests/test_violations_gate.py
+++ b/tests/test_violations_gate.py
@@ -119,3 +119,53 @@ async def test_generate_declaration_returns_gated_text_and_corrections(
     assert "multiple occasions" in body["declaration"]
     types = {c["type"] for c in body["corrections"]}
     assert {"date", "authority_removed", "quantifier_flag"} <= types
+
+
+SEMANTIC_FLAG = {
+    "type": "semantic_flag",
+    "severity": "needs_review",
+    "section": "reviewer",
+    "original": "multiple occasions",
+    "replacement": None,
+    "message": (
+        "Our automated reviewer flagged: The intake data does not say how many "
+        'attempts were made. — verify "multiple occasions" against your '
+        "records before filing."
+    ),
+}
+
+
+async def test_process_appends_semantic_flags_to_report(
+    client: AsyncClient, auth_headers: dict, monkeypatch
+):
+    await _create_profile(client, auth_headers)
+    _mock_enhance(monkeypatch)
+    check_text = AsyncMock(return_value=[dict(SEMANTIC_FLAG)])
+    monkeypatch.setattr(
+        violations_endpoint.semantic_check_service, "check_text", check_text
+    )
+
+    resp = await client.post(
+        "/api/v1/violations/process", json=_intake(), headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Reviewer flag appended after the gate's own corrections
+    assert body["corrections"][-1] == SEMANTIC_FLAG
+    assert {c["type"] for c in body["corrections"]} >= {
+        "authority_removed",
+        "semantic_flag",
+    }
+
+    # Reviewer sees the gated declaration, the raw intake, and the profile
+    check_text.assert_awaited_once()
+    args = check_text.await_args.args
+    assert args[0] == body["declaration"]
+    assert args[1]["violationType"] == "Visitation"
+    assert args[2]["party_name"] == "Rosa Martinez"
+
+    listing = await client.get("/api/v1/motions/", headers=auth_headers)
+    motion_id = [m for m in listing.json() if m["motion_type"] == "VIOLATION"][0]["id"]
+    detail = await client.get(f"/api/v1/motions/{motion_id}", headers=auth_headers)
+    assert detail.json()["fact_check"]["corrections"] == body["corrections"]


### PR DESCRIPTION
## Summary
Approved model-stack upgrade: **Opus 4.8 drafts, the deterministic fact gate corrects, and an Opus semantic refute-pass flags what regexes can't catch** — with Haiku 4.5 unchanged on utility ops (chat, extraction, classification).

- `feat(llm)`: drafting tier `claude-sonnet-4-6` → `claude-opus-4-8` (audited: our service sends no Opus-incompatible params; env override unchanged)
- `feat(llm)`: new `semantic_check` operation — one flag-only Opus call per motion after the gate, adversarially prompted to refute any claim unsupported by intake data; findings append to `fact_check` corrections and render in the existing review banner; fail-open with timeout, honest no-op under mock LLM
- `fix(llm)`: blank draft values no longer poison the gate's intake merge (`merge_intake_values`) — **found by the checker's first live run**: later drafts store blank re-registered values that overwrote real answers, causing the gate to strip genuine user facts ($3,200 income, $85 expense, June 14 date) as unverifiable

## Verification
- Backend suite: **544 passed / 3 xfailed** (+22 new tests), green after each commit, red-first confirmed per commit (merge-fix fixtures are the verbatim poisoned shapes from the live DB).
- Live browser runs (real Claude, ×2): Opus model id on every draft, ~54s/motion (comparable to Sonnet), correct FL-300 PDF, no markdown; post-fix run confirms all genuine facts survive and the checker's flags now surface a real drafting-quality issue (placeholders for provided case number/county — follow-up filed).

## Cost
~+$0.25–0.30 per motion vs the old stack (Opus drafting premium + one ~$0.07 checker call).

## Follow-ups (tracked in tasks/todo.md)
Dedup near-identical checker findings; extend gate placeholder-fill to case_number/county; frontend per-step-only saveDraft payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)