### PR TITLE
feat(billing): Stripe subscription paywall — $499 setup + $99/month

### DIFF
--- a/app/api/v1/chat_pdf.py
+++ b/app/api/v1/chat_pdf.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
 from app.core.deps import get_db, get_current_user
+from app.core.entitlements import require_active_subscription
 from app.models.user import User
 from app.services.chat_to_pdf_service import chat_to_pdf_service
 
@@ -57,7 +58,7 @@ async def prepare_motion_from_chat(
             detail=f"Error preparing motion: {str(e)}"
         )
 
-@router.post("/generate-pdf")
+@router.post("/generate-pdf", dependencies=[Depends(require_active_subscription)])
 async def generate_pdf_from_motion(
     request: GeneratePDFRequest,
     db: AsyncSession = Depends(get_db),
@@ -150,7 +151,7 @@ async def get_confirmation_summary(
             detail=f"Error creating summary: {str(e)}"
         )
 
-@router.post("/complete-workflow")
+@router.post("/complete-workflow", dependencies=[Depends(require_active_subscription)])
 async def complete_chat_to_pdf_workflow(
     request: PrepareMotionRequest,
     db: AsyncSession = Depends(get_db),

--- a/app/api/v1/endpoints/billing.py
+++ b/app/api/v1/endpoints/billing.py
@@ -1,0 +1,77 @@
+"""
+Billing endpoints: Stripe checkout, customer portal, subscription status
+"""
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_db, get_current_user
+from app.core.entitlements import is_entitled
+from app.models.subscription import Subscription
+from app.models.user import User
+from app.services import stripe_service
+
+router = APIRouter()
+
+
+class CheckoutRequest(BaseModel):
+    return_to: Optional[str] = None
+
+
+class VerifySessionRequest(BaseModel):
+    session_id: str
+
+
+def _status_payload(subscription: Optional[Subscription]) -> dict:
+    return {
+        "status": subscription.status if subscription else None,
+        "is_entitled": is_entitled(subscription),
+        "current_period_end": (
+            subscription.current_period_end.isoformat()
+            if subscription and subscription.current_period_end
+            else None
+        ),
+        "cancel_at_period_end": bool(subscription.cancel_at_period_end) if subscription else False,
+    }
+
+
+@router.post("/checkout-session")
+async def checkout_session(
+    request: CheckoutRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    url = await stripe_service.create_checkout_session(db, current_user, request.return_to)
+    return {"url": url}
+
+
+@router.post("/portal-session")
+async def portal_session(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    url = await stripe_service.create_portal_session(db, current_user)
+    return {"url": url}
+
+
+@router.get("/status")
+async def billing_status(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    subscription = await stripe_service.get_subscription_for_user(db, current_user.id)
+    return _status_payload(subscription)
+
+
+@router.post("/verify-session")
+async def verify_session(
+    request: VerifySessionRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    subscription = await stripe_service.sync_from_checkout_session(
+        db, current_user, request.session_id
+    )
+    return _status_payload(subscription)

--- a/app/api/v1/endpoints/documents.py
+++ b/app/api/v1/endpoints/documents.py
@@ -28,6 +28,7 @@ from app.models.motion import Motion, MotionDraft, Document
 from app.models.profile import Profile
 from app.api.v1.endpoints.auth import get_current_user
 from app.core.database import get_db
+from app.core.entitlements import require_active_subscription
 from app.core.config import settings
 from app.services.pdf_packet_service import generate_packet, primary_form_for
 
@@ -124,7 +125,11 @@ class PDFGenerationResponse(BaseModel):
     status: str
     download_url: Optional[str] = None
 
-@router.post("/generate-pdf", response_model=PDFGenerationResponse)
+@router.post(
+    "/generate-pdf",
+    response_model=PDFGenerationResponse,
+    dependencies=[Depends(require_active_subscription)],
+)
 async def generate_pdf(
     request: GeneratePDFRequest,
     background_tasks: BackgroundTasks,
@@ -228,7 +233,7 @@ async def generate_pdf_background(
     except Exception as e:
         logger.error(f"Error publishing to Pub/Sub: {str(e)}")
 
-@router.post("/generate-pdf-sync")
+@router.post("/generate-pdf-sync", dependencies=[Depends(require_active_subscription)])
 async def generate_pdf_sync(
     request: GeneratePDFRequest,
     current_user: User = Depends(get_current_user),
@@ -293,7 +298,7 @@ async def generate_pdf_sync(
             detail=f"Error generating PDF: {str(e)}"
         )
 
-@router.get("/{document_id}/download")
+@router.get("/{document_id}/download", dependencies=[Depends(require_active_subscription)])
 async def download_document(
     document_id: str,
     current_user: User = Depends(get_current_user),

--- a/app/api/v1/endpoints/llm.py
+++ b/app/api/v1/endpoints/llm.py
@@ -14,11 +14,12 @@ from app.models.motion import Motion, MotionDraft
 from app.models.profile import Profile
 from app.api.v1.endpoints.auth import get_current_user
 from app.core.database import get_db
+from app.core.entitlements import require_active_subscription
 from app.services import semantic_check_service
 from app.services.fact_gate import GateContext, merge_intake_values, run_fact_gate
 from app.services.llm_service import llm_service
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_active_subscription)])
 logger = logging.getLogger(__name__)
 
 class RewriteRequest(BaseModel):

--- a/app/api/v1/endpoints/stripe_webhook.py
+++ b/app/api/v1/endpoints/stripe_webhook.py
@@ -1,0 +1,32 @@
+"""
+Stripe webhook endpoint — unauthenticated, verified by signature
+"""
+import json
+import logging
+
+import stripe
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.services.stripe_service import apply_stripe_event
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("/stripe")
+async def stripe_webhook(request: Request, db: AsyncSession = Depends(get_db)):
+    payload = await request.body()
+    signature = request.headers.get("stripe-signature")
+    if not signature:
+        raise HTTPException(status_code=400, detail="Missing stripe-signature header")
+    try:
+        stripe.Webhook.construct_event(payload, signature, settings.STRIPE_WEBHOOK_SECRET)
+    except (ValueError, stripe.SignatureVerificationError):
+        logger.warning("Rejected stripe webhook with invalid signature")
+        raise HTTPException(status_code=400, detail="Invalid webhook signature")
+    # apply_stripe_event works on plain dicts; the payload is signature-verified
+    await apply_stripe_event(db, json.loads(payload))
+    return {"received": True}

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -2,7 +2,7 @@
 Main API router
 """
 from fastapi import APIRouter
-from app.api.v1.endpoints import auth, users, profiles, motions, llm, documents, intake, violations, evidence, evidence_batch, evidence_gmail, served_motion, billing
+from app.api.v1.endpoints import auth, users, profiles, motions, llm, documents, intake, violations, evidence, evidence_batch, evidence_gmail, served_motion, billing, stripe_webhook
 from app.api.v1 import chat, chat_pdf
 
 api_router = APIRouter()
@@ -17,6 +17,7 @@ api_router.include_router(llm.router, prefix="/llm", tags=["LLM"])
 api_router.include_router(served_motion.router, prefix="/llm", tags=["LLM"])
 api_router.include_router(documents.router, prefix="/documents", tags=["Documents"])
 api_router.include_router(billing.router, prefix="/billing", tags=["Billing"])
+api_router.include_router(stripe_webhook.router, prefix="/webhooks", tags=["Webhooks"])
 # violations and chat_pdf carry their own path prefixes; evidence and evidence_gmail
 # declare frontend-facing paths (/motions/..., /evidence/..., /gmail/...) directly.
 # Adding prefixes here doubled every path and broke the frontend contract.

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -2,7 +2,7 @@
 Main API router
 """
 from fastapi import APIRouter
-from app.api.v1.endpoints import auth, users, profiles, motions, llm, documents, intake, violations, evidence, evidence_batch, evidence_gmail, served_motion
+from app.api.v1.endpoints import auth, users, profiles, motions, llm, documents, intake, violations, evidence, evidence_batch, evidence_gmail, served_motion, billing
 from app.api.v1 import chat, chat_pdf
 
 api_router = APIRouter()
@@ -16,6 +16,7 @@ api_router.include_router(intake.router, prefix="/intake", tags=["Intake"])
 api_router.include_router(llm.router, prefix="/llm", tags=["LLM"])
 api_router.include_router(served_motion.router, prefix="/llm", tags=["LLM"])
 api_router.include_router(documents.router, prefix="/documents", tags=["Documents"])
+api_router.include_router(billing.router, prefix="/billing", tags=["Billing"])
 # violations and chat_pdf carry their own path prefixes; evidence and evidence_gmail
 # declare frontend-facing paths (/motions/..., /evidence/..., /gmail/...) directly.
 # Adding prefixes here doubled every path and broke the frontend contract.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -48,6 +48,12 @@ class Settings(BaseSettings):
         "https://motion-api-mlcaanldqq-uc.a.run.app"
     ]
     
+    # Stripe billing
+    STRIPE_SECRET_KEY: str = os.getenv("STRIPE_SECRET_KEY", "")
+    STRIPE_WEBHOOK_SECRET: str = os.getenv("STRIPE_WEBHOOK_SECRET", "")
+    STRIPE_PRICE_ID: str = os.getenv("STRIPE_PRICE_ID", "")
+    FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
     # Pub/Sub
     PUBSUB_TOPIC: str = os.getenv("PUBSUB_TOPIC", "app-events")
     

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -51,7 +51,8 @@ class Settings(BaseSettings):
     # Stripe billing
     STRIPE_SECRET_KEY: str = os.getenv("STRIPE_SECRET_KEY", "")
     STRIPE_WEBHOOK_SECRET: str = os.getenv("STRIPE_WEBHOOK_SECRET", "")
-    STRIPE_PRICE_ID: str = os.getenv("STRIPE_PRICE_ID", "")
+    STRIPE_PRICE_ID: str = os.getenv("STRIPE_PRICE_ID", "")  # $99/mo recurring
+    STRIPE_SETUP_PRICE_ID: str = os.getenv("STRIPE_SETUP_PRICE_ID", "")  # $499 one-time
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
 
     # Pub/Sub

--- a/app/core/entitlements.py
+++ b/app/core/entitlements.py
@@ -1,0 +1,44 @@
+"""
+Subscription entitlement gate for paid features (LLM drafting, PDF export)
+"""
+import os
+
+from fastapi import Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user
+from app.models.subscription import Subscription
+from app.models.user import User
+
+# past_due stays entitled: a failed renewal charge must not lock a user out
+# mid-motion. Revocation is delegated to Stripe dunning — when retries
+# exhaust, Stripe cancels the subscription and the webhook lands "canceled".
+ENTITLED_STATUSES = {"active", "trialing", "past_due"}
+
+
+def is_entitled(subscription: Subscription | None) -> bool:
+    return subscription is not None and subscription.status in ENTITLED_STATUSES
+
+
+async def require_active_subscription(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    # Read at request time (mirrors RATE_LIMIT_ENABLED) so tests and ops can
+    # flip the flag without a reimport
+    if os.getenv("BILLING_ENABLED", "true").lower() != "true":
+        return
+    result = await db.execute(
+        select(Subscription).where(Subscription.user_id == current_user.id)
+    )
+    if is_entitled(result.scalar_one_or_none()):
+        return
+    raise HTTPException(
+        status_code=402,
+        detail={
+            "code": "subscription_required",
+            "message": "An active subscription is required to draft and export motions.",
+        },
+    )

--- a/app/middleware/rate_limit_config.py
+++ b/app/middleware/rate_limit_config.py
@@ -27,6 +27,9 @@ RATE_LIMITS = {
     # Auth - brute-force and signup-abuse protection
     "/api/v1/auth/token": "20/hour",
     "/api/v1/auth/register": "10/hour",
+
+    # Billing - checkout sessions create Stripe objects
+    "/api/v1/billing/checkout-session": "10/hour",
 }
 
 # Token limits by operation type

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.chat import (
     ConversationTemplate
 )
 from app.models.evidence import Evidence
+from app.models.subscription import Subscription
 
 __all__ = [
     'User',
@@ -20,4 +21,5 @@ __all__ = [
     'ChatIntent',
     'ConversationTemplate',
     'Evidence',
+    'Subscription',
 ]

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,0 +1,41 @@
+"""
+Subscription model — Stripe billing state, one row per user
+"""
+from datetime import datetime
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, BigInteger
+from app.core.uuid_type import UUID
+from sqlalchemy.orm import relationship
+import uuid
+
+from app.core.database import Base
+
+
+class Subscription(Base):
+    __tablename__ = "subscriptions"
+
+    id = Column(UUID(), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(
+        UUID(),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    stripe_customer_id = Column(String(255), nullable=False, index=True)
+    stripe_subscription_id = Column(String(255), unique=True, index=True)
+
+    # Verbatim Stripe status snapshot (active, trialing, past_due, canceled, ...)
+    status = Column(String(50), nullable=False, default="incomplete")
+    price_id = Column(String(255))
+    current_period_end = Column(DateTime(timezone=True))
+    cancel_at_period_end = Column(Boolean, nullable=False, default=False)
+
+    # Stripe event.created of the last applied webhook event — guards
+    # against out-of-order delivery regressing newer state
+    last_event_created = Column(BigInteger)
+
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User", back_populates="subscription")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -28,6 +28,7 @@ class User(Base):
     profile = relationship("Profile", back_populates="user", uselist=False)
     motions = relationship("Motion", back_populates="user")
     chat_sessions = relationship("ChatSession", back_populates="user")
+    subscription = relationship("Subscription", back_populates="user", uselist=False)
 
 class Profile(Base):
     __tablename__ = "profiles"

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -35,7 +35,7 @@ def _sanitize_return_to(return_to: Optional[str]) -> str:
     return "/dashboard"
 
 
-async def _get_by_user(db: AsyncSession, user_id) -> Optional[Subscription]:
+async def get_subscription_for_user(db: AsyncSession, user_id) -> Optional[Subscription]:
     result = await db.execute(select(Subscription).where(Subscription.user_id == user_id))
     return result.scalar_one_or_none()
 
@@ -50,7 +50,7 @@ async def _get_by_customer(db: AsyncSession, customer_id) -> Optional[Subscripti
 
 
 async def get_or_create_customer(db: AsyncSession, user: User) -> Subscription:
-    row = await _get_by_user(db, user.id)
+    row = await get_subscription_for_user(db, user.id)
     if row:
         return row
     _stripe_ready()
@@ -91,7 +91,7 @@ async def create_checkout_session(
 
 
 async def create_portal_session(db: AsyncSession, user: User) -> str:
-    row = await _get_by_user(db, user.id)
+    row = await get_subscription_for_user(db, user.id)
     if row is None:
         raise HTTPException(
             status_code=404,
@@ -144,7 +144,7 @@ async def sync_from_checkout_session(db: AsyncSession, user: User, session_id: s
             status_code=403,
             detail={"code": "session_ownership_mismatch", "message": "Not your checkout session."},
         )
-    row = await _get_by_user(db, user.id)
+    row = await get_subscription_for_user(db, user.id)
     if row is None:
         row = Subscription(user_id=user.id, stripe_customer_id=session.get("customer") or "")
         db.add(row)

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -68,7 +68,7 @@ async def create_checkout_session(
     db: AsyncSession, user: User, return_to: Optional[str] = None
 ) -> str:
     _stripe_ready()
-    if not settings.STRIPE_PRICE_ID:
+    if not settings.STRIPE_PRICE_ID or not settings.STRIPE_SETUP_PRICE_ID:
         raise HTTPException(
             status_code=503,
             detail={"code": "billing_not_configured", "message": "Billing is not configured."},
@@ -80,7 +80,12 @@ async def create_checkout_session(
         mode="subscription",
         customer=row.stripe_customer_id,
         client_reference_id=str(user.id),
-        line_items=[{"price": settings.STRIPE_PRICE_ID, "quantity": 1}],
+        # One-time setup fee joins the first invoice; the recurring price
+        # defines the ongoing subscription
+        line_items=[
+            {"price": settings.STRIPE_SETUP_PRICE_ID, "quantity": 1},
+            {"price": settings.STRIPE_PRICE_ID, "quantity": 1},
+        ],
         success_url=(
             f"{settings.FRONTEND_URL}/#/billing/success"
             f"?session_id={{CHECKOUT_SESSION_ID}}&return_to={path}"

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -1,0 +1,211 @@
+"""
+Stripe billing service: customer/checkout/portal sessions and idempotent
+webhook event application onto the subscriptions table
+"""
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import stripe
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.subscription import Subscription
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+def _stripe_ready() -> None:
+    if not settings.STRIPE_SECRET_KEY:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "billing_not_configured", "message": "Billing is not configured."},
+        )
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+
+
+def _sanitize_return_to(return_to: Optional[str]) -> str:
+    # In-app path only — anything else would be an open redirect
+    if return_to and return_to.startswith("/") and not return_to.startswith("//"):
+        return return_to
+    return "/dashboard"
+
+
+async def _get_by_user(db: AsyncSession, user_id) -> Optional[Subscription]:
+    result = await db.execute(select(Subscription).where(Subscription.user_id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def _get_by_customer(db: AsyncSession, customer_id) -> Optional[Subscription]:
+    if not customer_id:
+        return None
+    result = await db.execute(
+        select(Subscription).where(Subscription.stripe_customer_id == customer_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_or_create_customer(db: AsyncSession, user: User) -> Subscription:
+    row = await _get_by_user(db, user.id)
+    if row:
+        return row
+    _stripe_ready()
+    customer = await asyncio.to_thread(
+        stripe.Customer.create, email=user.email, metadata={"user_id": str(user.id)}
+    )
+    row = Subscription(user_id=user.id, stripe_customer_id=customer["id"])
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def create_checkout_session(
+    db: AsyncSession, user: User, return_to: Optional[str] = None
+) -> str:
+    _stripe_ready()
+    if not settings.STRIPE_PRICE_ID:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "billing_not_configured", "message": "Billing is not configured."},
+        )
+    row = await get_or_create_customer(db, user)
+    path = _sanitize_return_to(return_to)
+    session = await asyncio.to_thread(
+        stripe.checkout.Session.create,
+        mode="subscription",
+        customer=row.stripe_customer_id,
+        client_reference_id=str(user.id),
+        line_items=[{"price": settings.STRIPE_PRICE_ID, "quantity": 1}],
+        success_url=(
+            f"{settings.FRONTEND_URL}/#/billing/success"
+            f"?session_id={{CHECKOUT_SESSION_ID}}&return_to={path}"
+        ),
+        cancel_url=f"{settings.FRONTEND_URL}/#/billing/canceled",
+    )
+    return session["url"]
+
+
+async def create_portal_session(db: AsyncSession, user: User) -> str:
+    row = await _get_by_user(db, user.id)
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "no_subscription", "message": "No subscription on file."},
+        )
+    _stripe_ready()
+    session = await asyncio.to_thread(
+        stripe.billing_portal.Session.create,
+        customer=row.stripe_customer_id,
+        return_url=f"{settings.FRONTEND_URL}/#/dashboard",
+    )
+    return session["url"]
+
+
+def _period_end(sub_obj: dict) -> Optional[datetime]:
+    ts = sub_obj.get("current_period_end")
+    if ts is None:
+        # Stripe API >= 2025-03-31 keeps the period on the subscription item
+        items = (sub_obj.get("items") or {}).get("data") or []
+        if items:
+            ts = items[0].get("current_period_end")
+    return datetime.fromtimestamp(ts, tz=timezone.utc) if ts else None
+
+
+def _apply_snapshot(row: Subscription, sub_obj: dict) -> None:
+    if sub_obj.get("id"):
+        row.stripe_subscription_id = sub_obj["id"]
+    if sub_obj.get("status"):
+        row.status = sub_obj["status"]
+    row.cancel_at_period_end = bool(sub_obj.get("cancel_at_period_end", False))
+    period_end = _period_end(sub_obj)
+    if period_end:
+        row.current_period_end = period_end
+    items = (sub_obj.get("items") or {}).get("data") or []
+    price_id = (items[0].get("price") or {}).get("id") if items else None
+    if price_id:
+        row.price_id = price_id
+
+
+def _is_stale(row: Subscription, event_created: int) -> bool:
+    return row.last_event_created is not None and event_created < row.last_event_created
+
+
+async def sync_from_checkout_session(db: AsyncSession, user: User, session_id: str) -> Subscription:
+    """Server-side sync right after the Checkout redirect, before the webhook lands."""
+    _stripe_ready()
+    session = await asyncio.to_thread(stripe.checkout.Session.retrieve, session_id)
+    if session.get("client_reference_id") != str(user.id):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "session_ownership_mismatch", "message": "Not your checkout session."},
+        )
+    row = await _get_by_user(db, user.id)
+    if row is None:
+        row = Subscription(user_id=user.id, stripe_customer_id=session.get("customer") or "")
+        db.add(row)
+    subscription_id = session.get("subscription")
+    if subscription_id:
+        sub_obj = await asyncio.to_thread(stripe.Subscription.retrieve, subscription_id)
+        _apply_snapshot(row, sub_obj)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def apply_stripe_event(db: AsyncSession, event: dict) -> None:
+    """Apply one webhook event. Absolute snapshots + last_event_created guard
+    make replays harmless and out-of-order deliveries inert."""
+    event_type = event.get("type", "")
+    event_created = event.get("created") or 0
+    obj = (event.get("data") or {}).get("object") or {}
+
+    if event_type == "checkout.session.completed":
+        row = await _get_by_customer(db, obj.get("customer"))
+        if row is None:
+            logger.warning("Stripe checkout completed for unknown customer %s", obj.get("customer"))
+            return
+        if _is_stale(row, event_created):
+            return
+        subscription_id = obj.get("subscription")
+        if subscription_id:
+            row.stripe_subscription_id = subscription_id
+            _stripe_ready()
+            # Live retrieve is always-current, immune to event ordering
+            sub_obj = await asyncio.to_thread(stripe.Subscription.retrieve, subscription_id)
+            _apply_snapshot(row, sub_obj)
+        row.last_event_created = event_created
+        await db.commit()
+    elif event_type in (
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    ):
+        row = await _get_by_customer(db, obj.get("customer"))
+        if row is None:
+            logger.warning("Stripe %s for unknown customer %s", event_type, obj.get("customer"))
+            return
+        if _is_stale(row, event_created):
+            return
+        _apply_snapshot(row, obj)
+        row.last_event_created = event_created
+        await db.commit()
+    elif event_type == "invoice.payment_failed":
+        if not obj.get("subscription"):
+            return
+        row = await _get_by_customer(db, obj.get("customer"))
+        if row is None:
+            logger.warning("Stripe payment_failed for unknown customer %s", obj.get("customer"))
+            return
+        if _is_stale(row, event_created):
+            return
+        row.status = "past_due"
+        row.last_event_created = event_created
+        await db.commit()
+        logger.info("Subscription for customer %s marked past_due", obj.get("customer"))
+    else:
+        logger.info("Ignoring stripe event type %s", event_type)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,8 @@ import { GmailCallback } from './components/evidence/GmailCallback';
 import { PrivacyPolicy } from './components/legal/PrivacyPolicy';
 import { Terms } from './components/legal/Terms';
 import { LegalFooter } from './components/legal/LegalFooter';
+import { BillingSuccess } from './components/billing/BillingSuccess';
+import { BillingCanceled } from './components/billing/BillingCanceled';
 
 function App() {
   return (
@@ -169,6 +171,24 @@ function App() {
             element={
               <PrivateRoute>
                 <GmailCallback />
+              </PrivateRoute>
+            }
+          />
+
+          {/* Stripe checkout return routes */}
+          <Route
+            path="/billing/success"
+            element={
+              <PrivateRoute>
+                <BillingSuccess />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/billing/canceled"
+            element={
+              <PrivateRoute>
+                <BillingCanceled />
               </PrivateRoute>
             }
           />

--- a/frontend/src/__mocks__/react-router-dom.tsx
+++ b/frontend/src/__mocks__/react-router-dom.tsx
@@ -9,3 +9,4 @@ export const Navigate = ({ to }: { to: string }) => <div>Navigate to {to}</div>;
 export const useNavigate = () => jest.fn();
 export const useLocation = () => ({ pathname: '/', search: '', hash: '', state: null });
 export const useParams = () => ({});
+export const useSearchParams = () => [new URLSearchParams(''), jest.fn()];

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { BillingButton } from './billing/BillingButton';
 import { motionAPI, profileAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import {
@@ -107,6 +108,7 @@ export const Dashboard: React.FC = () => {
               </p>
             </div>
             <div className="flex space-x-3">
+              <BillingButton />
               <button
                 onClick={() => navigate('/profile/setup')}
                 className="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"

--- a/frontend/src/components/__tests__/BillingButton.test.tsx
+++ b/frontend/src/components/__tests__/BillingButton.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * BillingButton: Dashboard entry point — Subscribe when unsubscribed,
+ * Manage billing (portal) when entitled.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BillingButton } from '../billing/BillingButton';
+
+const mockGetStatus = jest.fn();
+const mockCreateCheckoutSession = jest.fn();
+const mockCreatePortalSession = jest.fn();
+
+jest.mock('../../services/billing', () => ({
+  billingAPI: {
+    getStatus: (...args: any[]) => mockGetStatus(...args),
+    createCheckoutSession: (...args: any[]) => mockCreateCheckoutSession(...args),
+    createPortalSession: (...args: any[]) => mockCreatePortalSession(...args),
+  },
+}));
+
+const assignMock = jest.fn();
+const originalLocation = window.location;
+
+beforeAll(() => {
+  delete (window as any).location;
+  (window as any).location = { ...originalLocation, assign: assignMock };
+});
+
+afterAll(() => {
+  (window as any).location = originalLocation;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('shows Subscribe and starts checkout when not entitled', async () => {
+  mockGetStatus.mockResolvedValue({ status: null, is_entitled: false });
+  mockCreateCheckoutSession.mockResolvedValue({ url: 'https://checkout.stripe.com/x' });
+
+  render(<BillingButton />);
+  fireEvent.click(await screen.findByRole('button', { name: /subscribe/i }));
+
+  await waitFor(() => {
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith('/dashboard');
+    expect(assignMock).toHaveBeenCalledWith('https://checkout.stripe.com/x');
+  });
+});
+
+test('shows Manage billing and opens the portal when entitled', async () => {
+  mockGetStatus.mockResolvedValue({ status: 'active', is_entitled: true });
+  mockCreatePortalSession.mockResolvedValue({ url: 'https://billing.stripe.com/x' });
+
+  render(<BillingButton />);
+  fireEvent.click(await screen.findByRole('button', { name: /manage billing/i }));
+
+  await waitFor(() => {
+    expect(assignMock).toHaveBeenCalledWith('https://billing.stripe.com/x');
+  });
+});
+
+test('renders nothing while status is unknown', async () => {
+  mockGetStatus.mockRejectedValue(new Error('network'));
+
+  const { container } = render(<BillingButton />);
+
+  await waitFor(() => {
+    expect(mockGetStatus).toHaveBeenCalled();
+  });
+  expect(container).toBeEmptyDOMElement();
+});

--- a/frontend/src/components/__tests__/BillingSuccess.test.tsx
+++ b/frontend/src/components/__tests__/BillingSuccess.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * BillingSuccess: verifies the checkout session, polls status until entitled,
+ * then offers the guided-session link and Continue back into the app.
+ * BillingCanceled: reassures nothing was charged.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { BillingSuccess } from '../billing/BillingSuccess';
+import { BillingCanceled } from '../billing/BillingCanceled';
+
+const mockNavigate = jest.fn();
+let mockSearchParams = new URLSearchParams('session_id=cs_1&return_to=/motion/1/preview');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams, jest.fn()],
+}));
+
+const mockVerifySession = jest.fn();
+const mockGetStatus = jest.fn();
+
+jest.mock('../../services/billing', () => ({
+  billingAPI: {
+    verifySession: (...args: any[]) => mockVerifySession(...args),
+    getStatus: (...args: any[]) => mockGetStatus(...args),
+  },
+}));
+
+const renderSuccess = () =>
+  render(<BrowserRouter><BillingSuccess pollIntervalMs={1} /></BrowserRouter>);
+
+describe('BillingSuccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams('session_id=cs_1&return_to=/motion/1/preview');
+    process.env.REACT_APP_SCHEDULING_URL = 'https://calendar.app/sam';
+  });
+
+  test('verify-session success activates immediately without polling', async () => {
+    mockVerifySession.mockResolvedValue({ status: 'active', is_entitled: true });
+
+    renderSuccess();
+
+    expect(await screen.findByText(/subscribed/i)).toBeInTheDocument();
+    expect(mockVerifySession).toHaveBeenCalledWith('cs_1');
+    expect(mockGetStatus).not.toHaveBeenCalled();
+    expect(screen.getByRole('link', { name: /schedule/i })).toHaveAttribute(
+      'href',
+      'https://calendar.app/sam'
+    );
+  });
+
+  test('falls back to polling status until entitled', async () => {
+    mockVerifySession.mockRejectedValue(new Error('stripe hiccup'));
+    mockGetStatus
+      .mockResolvedValueOnce({ status: 'incomplete', is_entitled: false })
+      .mockResolvedValueOnce({ status: 'active', is_entitled: true });
+
+    renderSuccess();
+
+    expect(await screen.findByText(/subscribed/i)).toBeInTheDocument();
+    expect(mockGetStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test('shows an error state when activation never confirms', async () => {
+    mockVerifySession.mockRejectedValue(new Error('stripe hiccup'));
+    mockGetStatus.mockResolvedValue({ status: 'incomplete', is_entitled: false });
+
+    renderSuccess();
+
+    expect(await screen.findByText(/taking longer than expected/i)).toBeInTheDocument();
+  });
+
+  test('continue navigates to return_to', async () => {
+    mockVerifySession.mockResolvedValue({ status: 'active', is_entitled: true });
+
+    renderSuccess();
+    fireEvent.click(await screen.findByRole('button', { name: /continue/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/motion/1/preview');
+  });
+});
+
+describe('BillingCanceled', () => {
+  test('states nothing was charged with a way back', () => {
+    render(<BrowserRouter><BillingCanceled /></BrowserRouter>);
+
+    expect(screen.getByText(/nothing was charged/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to dashboard/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/GuidedIntakePaywall.test.tsx
+++ b/frontend/src/components/__tests__/GuidedIntakePaywall.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * GuidedIntake paywall: a 402 from LLM processing opens the paywall modal and
+ * stops navigation; other errors keep the existing llmFailed fallback.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { GuidedIntake } from '../motion/GuidedIntake';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ motionType: 'FL_300', formType: undefined }),
+  useLocation: () => ({ state: null, pathname: '/' }),
+}));
+
+jest.mock('../../services/servedMotionApi', () => ({
+  servedMotionAPI: { parse: jest.fn() },
+}));
+
+jest.mock('../../types/forms', () => ({
+  FORM_METADATA: { FL_300: { name: 'Request for Order', id: 'FL-300' } },
+  FORM_TYPES: { FL_300: 'FL_300' },
+  FormType: {},
+}));
+
+const MOCK_STEP_DATA = {
+  step_number: 1,
+  step_name: 'Case Information',
+  description: 'Basic case info',
+  questions: [{ id: 'party_name', type: 'text', label: 'Your Name', required: true }],
+  total_steps: 1,
+};
+
+const mockGetProfile = jest.fn();
+const mockCreate = jest.fn();
+const mockSaveDraft = jest.fn();
+const mockGetDrafts = jest.fn();
+const mockProcessWithLLM = jest.fn();
+const mockGetQuestions = jest.fn();
+const mockEvaluateCondition = jest.fn();
+const mockCreateCheckoutSession = jest.fn();
+
+jest.mock('../../services/api', () => ({
+  profileAPI: {
+    getProfile: (...args: any[]) => mockGetProfile(...args),
+  },
+  motionAPI: {
+    create: (...args: any[]) => mockCreate(...args),
+    saveDraft: (...args: any[]) => mockSaveDraft(...args),
+    getDrafts: (...args: any[]) => mockGetDrafts(...args),
+    processWithLLM: (...args: any[]) => mockProcessWithLLM(...args),
+  },
+  intakeAPI: {
+    getQuestions: (...args: any[]) => mockGetQuestions(...args),
+    evaluateCondition: (...args: any[]) => mockEvaluateCondition(...args),
+  },
+}));
+
+jest.mock('../../services/billing', () => ({
+  billingAPI: {
+    createCheckoutSession: (...args: any[]) => mockCreateCheckoutSession(...args),
+  },
+  isPaywallError: (error: any) => error?.response?.status === 402,
+}));
+
+const assignMock = jest.fn();
+const originalLocation = window.location;
+
+beforeAll(() => {
+  delete (window as any).location;
+  (window as any).location = { ...originalLocation, assign: assignMock };
+});
+
+afterAll(() => {
+  (window as any).location = originalLocation;
+});
+
+const renderWithRouter = () => render(<BrowserRouter><GuidedIntake /></BrowserRouter>);
+
+const submitFinalStep = async () => {
+  const input = await screen.findByLabelText(/Your Name/i);
+  fireEvent.change(input, { target: { value: 'Jane Doe' } });
+  fireEvent.click(screen.getByRole('button', { name: /complete/i }));
+};
+
+describe('GuidedIntake paywall', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreate.mockResolvedValue({ id: 'motion-123' });
+    mockGetDrafts.mockResolvedValue([]);
+    mockSaveDraft.mockResolvedValue({ success: true });
+    mockGetQuestions.mockResolvedValue({ data: MOCK_STEP_DATA });
+    mockEvaluateCondition.mockResolvedValue({ data: { result: true } });
+    mockGetProfile.mockResolvedValue(null);
+  });
+
+  test('402 opens the paywall modal and does not navigate', async () => {
+    mockProcessWithLLM.mockRejectedValue({ response: { status: 402 } });
+    renderWithRouter();
+    await submitFinalStep();
+
+    expect(await screen.findByText(/60-day money-back guarantee/i)).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('subscribe from the intake paywall returns to the final step', async () => {
+    mockProcessWithLLM.mockRejectedValue({ response: { status: 402 } });
+    mockCreateCheckoutSession.mockResolvedValue({ url: 'https://checkout.stripe.com/x' });
+    renderWithRouter();
+    await submitFinalStep();
+
+    fireEvent.click(await screen.findByRole('button', { name: /subscribe/i }));
+
+    await waitFor(() => {
+      expect(mockCreateCheckoutSession).toHaveBeenCalledWith('/motion/motion-123/edit/1');
+    });
+  });
+
+  test('non-402 errors keep the llmFailed fallback to preview', async () => {
+    mockProcessWithLLM.mockRejectedValue(new Error('llm exploded'));
+    renderWithRouter();
+    await submitFinalStep();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/motion/motion-123/preview', {
+        state: { llmFailed: true },
+      });
+    });
+    expect(screen.queryByText(/60-day money-back guarantee/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/MotionPreviewPaywall.test.tsx
+++ b/frontend/src/components/__tests__/MotionPreviewPaywall.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * MotionPreview paywall: a 402 from PDF generation opens the paywall modal
+ * instead of the generic error; other failures keep the generic error.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { MotionPreview } from '../motion/MotionPreview';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ motionId: 'motion-123' }),
+  useLocation: () => ({ state: null, pathname: '/motion/motion-123/preview' }),
+}));
+
+jest.mock('date-fns', () => ({
+  format: (_date: Date, _fmt: string) => 'Jun 10, 2026',
+}));
+
+const mockGetMotion = jest.fn();
+const mockGetDrafts = jest.fn();
+const mockGeneratePDFSync = jest.fn();
+const mockGetProfile = jest.fn();
+const mockCreateCheckoutSession = jest.fn();
+
+jest.mock('../../services/api', () => ({
+  motionAPI: {
+    get: (...args: any[]) => mockGetMotion(...args),
+    getDrafts: (...args: any[]) => mockGetDrafts(...args),
+  },
+  documentAPI: {
+    generatePDFSync: (...args: any[]) => mockGeneratePDFSync(...args),
+  },
+  profileAPI: {
+    get: (...args: any[]) => mockGetProfile(...args),
+  },
+}));
+
+jest.mock('../../services/billing', () => ({
+  billingAPI: {
+    createCheckoutSession: (...args: any[]) => mockCreateCheckoutSession(...args),
+  },
+  isPaywallError: (error: any) => error?.response?.status === 402,
+}));
+
+const mockMotion = {
+  id: 'motion-123',
+  motion_type: 'RFO',
+  case_caption: 'Smith v. Smith',
+  case_number: 'FL-2024-001',
+  filing_date: '',
+  hearing_date: '',
+  hearing_time: '',
+  status: 'complete',
+};
+
+const mockDrafts = [
+  {
+    id: 'draft-1',
+    step_number: 1,
+    step_name: 'Case Information',
+    question_data: { party_name: 'Jane' },
+    llm_output: 'Petitioner Jane respectfully requests...',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+];
+
+const assignMock = jest.fn();
+const originalLocation = window.location;
+
+beforeAll(() => {
+  delete (window as any).location;
+  (window as any).location = { ...originalLocation, assign: assignMock };
+});
+
+afterAll(() => {
+  (window as any).location = originalLocation;
+});
+
+const clickDownload = async () => {
+  await waitFor(() => {
+    expect(screen.getAllByRole('button', { name: /Download PDF/i }).length).toBeGreaterThan(0);
+  });
+  fireEvent.click(screen.getAllByRole('button', { name: /Download PDF/i })[0]);
+};
+
+describe('MotionPreview paywall', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMotion.mockResolvedValue(mockMotion);
+    mockGetDrafts.mockResolvedValue(mockDrafts);
+    mockGetProfile.mockRejectedValue(new Error('No profile'));
+  });
+
+  test('402 opens the paywall modal instead of the generic error', async () => {
+    mockGeneratePDFSync.mockRejectedValue({ response: { status: 402 } });
+
+    render(<BrowserRouter><MotionPreview /></BrowserRouter>);
+    await clickDownload();
+
+    expect(await screen.findByText(/60-day money-back guarantee/i)).toBeInTheDocument();
+    expect(screen.queryByText(/PDF generation failed/i)).toBeNull();
+  });
+
+  test('subscribe from the preview paywall returns to the preview page', async () => {
+    mockGeneratePDFSync.mockRejectedValue({ response: { status: 402 } });
+    mockCreateCheckoutSession.mockResolvedValue({ url: 'https://checkout.stripe.com/x' });
+
+    render(<BrowserRouter><MotionPreview /></BrowserRouter>);
+    await clickDownload();
+
+    fireEvent.click(await screen.findByRole('button', { name: /subscribe/i }));
+
+    await waitFor(() => {
+      expect(mockCreateCheckoutSession).toHaveBeenCalledWith('/motion/motion-123/preview');
+    });
+  });
+
+  test('non-402 failures keep the generic error without the modal', async () => {
+    mockGeneratePDFSync.mockRejectedValue(new Error('boom'));
+
+    render(<BrowserRouter><MotionPreview /></BrowserRouter>);
+    await clickDownload();
+
+    expect(await screen.findByText(/PDF generation failed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/60-day money-back guarantee/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/PaywallModal.test.tsx
+++ b/frontend/src/components/__tests__/PaywallModal.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for PaywallModal component
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PaywallModal } from '../billing/PaywallModal';
+
+const mockCreateCheckoutSession = jest.fn();
+
+jest.mock('../../services/billing', () => ({
+  billingAPI: {
+    createCheckoutSession: (...args: any[]) => mockCreateCheckoutSession(...args),
+  },
+}));
+
+const assignMock = jest.fn();
+const originalLocation = window.location;
+
+beforeAll(() => {
+  delete (window as any).location;
+  (window as any).location = { ...originalLocation, assign: assignMock };
+});
+
+afterAll(() => {
+  (window as any).location = originalLocation;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders offer copy when open', () => {
+  render(<PaywallModal isOpen onClose={jest.fn()} returnTo="/dashboard" />);
+
+  expect(screen.getByText(/\$300/)).toBeInTheDocument();
+  expect(screen.getByText(/60-day money-back guarantee/i)).toBeInTheDocument();
+  expect(screen.getByText(/guided session/i)).toBeInTheDocument();
+});
+
+test('renders nothing when closed', () => {
+  const { container } = render(
+    <PaywallModal isOpen={false} onClose={jest.fn()} returnTo="/dashboard" />
+  );
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('subscribe requests checkout session with returnTo and redirects', async () => {
+  mockCreateCheckoutSession.mockResolvedValueOnce({ url: 'https://checkout.stripe.com/x' });
+
+  render(<PaywallModal isOpen onClose={jest.fn()} returnTo="/motion/1/preview" />);
+  fireEvent.click(screen.getByRole('button', { name: /subscribe/i }));
+
+  await waitFor(() => {
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith('/motion/1/preview');
+    expect(assignMock).toHaveBeenCalledWith('https://checkout.stripe.com/x');
+  });
+});
+
+test('shows error when checkout session fails', async () => {
+  mockCreateCheckoutSession.mockRejectedValueOnce(new Error('network'));
+
+  render(<PaywallModal isOpen onClose={jest.fn()} returnTo="/dashboard" />);
+  fireEvent.click(screen.getByRole('button', { name: /subscribe/i }));
+
+  expect(await screen.findByText(/couldn't start checkout/i)).toBeInTheDocument();
+  expect(assignMock).not.toHaveBeenCalled();
+});
+
+test('close button calls onClose', () => {
+  const onClose = jest.fn();
+  render(<PaywallModal isOpen onClose={onClose} returnTo="/dashboard" />);
+
+  fireEvent.click(screen.getByRole('button', { name: /not now/i }));
+  expect(onClose).toHaveBeenCalled();
+});

--- a/frontend/src/components/__tests__/PaywallModal.test.tsx
+++ b/frontend/src/components/__tests__/PaywallModal.test.tsx
@@ -33,7 +33,8 @@ beforeEach(() => {
 test('renders offer copy when open', () => {
   render(<PaywallModal isOpen onClose={jest.fn()} returnTo="/dashboard" />);
 
-  expect(screen.getByText(/\$300/)).toBeInTheDocument();
+  expect(screen.getByText(/\$499/)).toBeInTheDocument();
+  expect(screen.getByText(/\$99\/month/i)).toBeInTheDocument();
   expect(screen.getByText(/60-day money-back guarantee/i)).toBeInTheDocument();
   expect(screen.getByText(/guided session/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/__tests__/intakeNavigation.test.ts
+++ b/frontend/src/components/__tests__/intakeNavigation.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests for navigateAfterIntake routing helper
+ */
+import { navigateAfterIntake } from '../motion/intakeNavigation';
+
+test('calls onComplete and navigates to preview with llmFailed state', () => {
+  const navigate = jest.fn();
+  const onComplete = jest.fn();
+
+  navigateAfterIntake(navigate as any, 'motion-1', null, true, onComplete);
+
+  expect(onComplete).toHaveBeenCalledWith('motion-1');
+  expect(navigate).toHaveBeenCalledWith('/motion/motion-1/preview', {
+    state: { llmFailed: true },
+  });
+});
+
+test('returns to FormExecution with completed index when launched from it', () => {
+  const navigate = jest.fn();
+  const locationState = { fromFormExecution: true, formExecutionFormIndex: 2 };
+
+  navigateAfterIntake(navigate as any, 'motion-1', locationState, false);
+
+  expect(navigate).toHaveBeenCalledWith('/case/forms', {
+    state: { ...locationState, completedFormIndex: 2 },
+  });
+});

--- a/frontend/src/components/billing/BillingButton.tsx
+++ b/frontend/src/components/billing/BillingButton.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { billingAPI, BillingStatus } from '../../services/billing';
+
+export const BillingButton: React.FC = () => {
+  const [status, setStatus] = useState<BillingStatus | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setStatus(await billingAPI.getStatus());
+      } catch {
+        // Billing unreachable — render nothing rather than a broken button
+      }
+    })();
+  }, []);
+
+  const openPortal = async () => {
+    try {
+      const { url } = await billingAPI.createPortalSession();
+      window.location.assign(url);
+    } catch {
+      // Portal unavailable; leave the dashboard as-is
+    }
+  };
+
+  const openCheckout = async () => {
+    try {
+      const { url } = await billingAPI.createCheckoutSession('/dashboard');
+      window.location.assign(url);
+    } catch {
+      // Checkout unavailable; leave the dashboard as-is
+    }
+  };
+
+  if (!status) return null;
+
+  return status.is_entitled ? (
+    <button
+      onClick={openPortal}
+      className="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+    >
+      Manage billing
+    </button>
+  ) : (
+    <button
+      onClick={openCheckout}
+      className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+    >
+      Subscribe
+    </button>
+  );
+};

--- a/frontend/src/components/billing/BillingCanceled.tsx
+++ b/frontend/src/components/billing/BillingCanceled.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export const BillingCanceled: React.FC = () => (
+  <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="bg-white rounded-lg shadow max-w-md w-full p-8 text-center">
+      <h2 className="text-xl font-semibold text-gray-900">Checkout canceled</h2>
+      <p className="mt-2 text-sm text-gray-600">
+        Nothing was charged. Your answers and drafts are still saved — you can subscribe
+        whenever you're ready.
+      </p>
+      <Link
+        to="/dashboard"
+        className="mt-4 inline-block w-full px-4 py-2 rounded-md text-white bg-primary-600 hover:bg-primary-700 font-medium"
+      >
+        Back to dashboard
+      </Link>
+    </div>
+  </div>
+);

--- a/frontend/src/components/billing/BillingSuccess.tsx
+++ b/frontend/src/components/billing/BillingSuccess.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { billingAPI } from '../../services/billing';
+
+const MAX_POLLS = 5;
+
+interface BillingSuccessProps {
+  pollIntervalMs?: number;
+}
+
+export const BillingSuccess: React.FC<BillingSuccessProps> = ({ pollIntervalMs = 2000 }) => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [phase, setPhase] = useState<'activating' | 'active' | 'error'>('activating');
+
+  const sessionId = searchParams.get('session_id');
+  const returnTo = searchParams.get('return_to') || '/dashboard';
+  const schedulingUrl = process.env.REACT_APP_SCHEDULING_URL;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const activate = async () => {
+      // Primary: server-side session verification beats the webhook race
+      if (sessionId) {
+        try {
+          const status = await billingAPI.verifySession(sessionId);
+          if (status.is_entitled) {
+            if (!cancelled) setPhase('active');
+            return;
+          }
+        } catch {
+          // fall through to polling
+        }
+      }
+      // Fallback: the webhook may land a moment later
+      for (let attempt = 0; attempt < MAX_POLLS; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+        if (cancelled) return;
+        try {
+          const status = await billingAPI.getStatus();
+          if (status.is_entitled) {
+            setPhase('active');
+            return;
+          }
+        } catch {
+          // keep polling
+        }
+      }
+      if (!cancelled) setPhase('error');
+    };
+
+    activate();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, pollIntervalMs]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-lg shadow max-w-md w-full p-8 text-center">
+        {phase === 'activating' && (
+          <>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto mb-4"></div>
+            <p className="text-gray-700 text-lg">Activating your subscription…</p>
+          </>
+        )}
+        {phase === 'active' && (
+          <>
+            <h2 className="text-2xl font-semibold text-gray-900">You're subscribed!</h2>
+            <p className="mt-2 text-sm text-gray-600">
+              Motion drafting and PDF export are now unlocked. Remember: you're covered by our
+              60-day money-back guarantee.
+            </p>
+            {schedulingUrl && (
+              <a
+                href={schedulingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 inline-block w-full px-4 py-2 rounded-md text-primary-700 bg-white border border-primary-300 hover:bg-primary-50 font-medium"
+              >
+                Schedule your 1-on-1 session
+              </a>
+            )}
+            <button
+              onClick={() => navigate(returnTo)}
+              className="mt-3 w-full px-4 py-2 rounded-md text-white bg-primary-600 hover:bg-primary-700 font-medium"
+            >
+              Continue
+            </button>
+          </>
+        )}
+        {phase === 'error' && (
+          <>
+            <h2 className="text-xl font-semibold text-gray-900">
+              Activation is taking longer than expected
+            </h2>
+            <p className="mt-2 text-sm text-gray-600">
+              Your payment went through, but we haven't received confirmation yet. Wait a moment
+              and refresh this page — if it persists, contact support and we'll sort it out.
+            </p>
+            <button
+              onClick={() => navigate('/dashboard')}
+              className="mt-4 w-full px-4 py-2 rounded-md text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 font-medium"
+            >
+              Back to dashboard
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/billing/PaywallModal.tsx
+++ b/frontend/src/components/billing/PaywallModal.tsx
@@ -31,9 +31,9 @@ export const PaywallModal: React.FC<PaywallModalProps> = ({ isOpen, onClose, ret
         <h2 className="text-xl font-semibold text-gray-900">
           Unlock motion drafting &amp; PDF export
         </h2>
-        <p className="mt-2 text-3xl font-bold text-gray-900">$300</p>
+        <p className="mt-2 text-3xl font-bold text-gray-900">$499</p>
         <p className="text-sm text-gray-600">
-          Recurring plan — your exact billing period is shown at checkout.
+          One-time to get started, then $99/month while you need us.
         </p>
         <ul className="mt-4 space-y-2 text-sm text-gray-700">
           <li>✓ AI-drafted, court-ready motions and PDF export</li>

--- a/frontend/src/components/billing/PaywallModal.tsx
+++ b/frontend/src/components/billing/PaywallModal.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { billingAPI } from '../../services/billing';
+
+interface PaywallModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  returnTo: string;
+}
+
+export const PaywallModal: React.FC<PaywallModalProps> = ({ isOpen, onClose, returnTo }) => {
+  const [redirecting, setRedirecting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!isOpen) return null;
+
+  const subscribe = async () => {
+    setError('');
+    setRedirecting(true);
+    try {
+      const { url } = await billingAPI.createCheckoutSession(returnTo);
+      window.location.assign(url);
+    } catch {
+      setError("We couldn't start checkout. Please try again.");
+      setRedirecting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+        <h2 className="text-xl font-semibold text-gray-900">
+          Unlock motion drafting &amp; PDF export
+        </h2>
+        <p className="mt-2 text-3xl font-bold text-gray-900">$300</p>
+        <p className="text-sm text-gray-600">
+          Recurring plan — your exact billing period is shown at checkout.
+        </p>
+        <ul className="mt-4 space-y-2 text-sm text-gray-700">
+          <li>✓ AI-drafted, court-ready motions and PDF export</li>
+          <li>✓ 60-day money-back guarantee — no questions asked</li>
+          <li>✓ Includes a 1-on-1 guided session to walk through the process together</li>
+          <li>✓ Intake, gameplan, and evidence tools stay free</li>
+          <li>✓ Cancel anytime</li>
+        </ul>
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        <div className="mt-6 flex flex-col gap-2">
+          <button
+            onClick={subscribe}
+            disabled={redirecting}
+            className="w-full px-4 py-2 rounded-md text-white bg-primary-600 hover:bg-primary-700 font-medium disabled:opacity-50"
+          >
+            {redirecting ? 'Opening secure checkout…' : 'Subscribe'}
+          </button>
+          <button
+            onClick={onClose}
+            className="w-full px-4 py-2 rounded-md text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 font-medium"
+          >
+            Not now
+          </button>
+        </div>
+        <p className="mt-3 text-xs text-gray-500">
+          Secure payment by Stripe. You'll be redirected to complete your purchase.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/motion/GuidedIntake.tsx
+++ b/frontend/src/components/motion/GuidedIntake.tsx
@@ -15,6 +15,9 @@ import { IntakeProgressBar, IntakeStepDots } from './IntakeProgress';
 import { IntakeStepForm } from './IntakeStepForm';
 import { IntakeNotices } from './IntakeNotices';
 import { IntakeErrorBanner } from './IntakeErrorBanner';
+import { navigateAfterIntake } from './intakeNavigation';
+import { isPaywallError } from '../../services/billing';
+import { PaywallModal } from '../billing/PaywallModal';
 
 interface GuidedIntakeProps {
   onComplete?: (motionId: string) => void;
@@ -45,6 +48,7 @@ export const GuidedIntake: React.FC<GuidedIntakeProps> = ({ onComplete }) => {
   // FL-320: skippable "upload the motion you were served" gate before step 1.
   // Resume skips it — the served motion was already handled on first entry.
   const [showUploadGate, setShowUploadGate] = useState(isResponseForm && !isResume);
+  const [showPaywall, setShowPaywall] = useState(false);
   // Track last visible question IDs to avoid infinite update loops from evaluateConditionalQuestions
   const visibleQuestionIdsRef = useRef<string>('');
 
@@ -178,31 +182,18 @@ export const GuidedIntake: React.FC<GuidedIntakeProps> = ({ onComplete }) => {
       try {
         await motionAPI.processWithLLM(motionId!);
       } catch (llmError) {
+        if (isPaywallError(llmError)) {
+          // Drafts are saved — after subscribing the user resumes this step
+          setShowPaywall(true);
+          return;
+        }
         console.error('LLM processing failed, proceeding with user words:', llmError);
         llmFailed = true;
       } finally {
         setProcessingLLM(false);
       }
 
-      if (onComplete) {
-        onComplete(motionId!);
-      }
-
-      // If launched from FormExecution, navigate back to signal completion.
-      // FormExecution is mounted at /case/forms — there is no /form/execution route.
-      if (locationState?.fromFormExecution) {
-        navigate('/case/forms', {
-          state: {
-            ...locationState,
-            completedFormIndex: locationState.formExecutionFormIndex,
-          },
-        });
-        return;
-      }
-
-      navigate(`/motion/${motionId}/preview`, {
-        state: { llmFailed },
-      });
+      navigateAfterIntake(navigate, motionId!, locationState, llmFailed, onComplete);
     } catch (error) {
       console.error('Failed to save step:', error);
       setSaveError(
@@ -293,6 +284,12 @@ export const GuidedIntake: React.FC<GuidedIntakeProps> = ({ onComplete }) => {
           currentStep={currentStep}
           totalSteps={totalSteps}
           onStepSelect={setCurrentStep}
+        />
+
+        <PaywallModal
+          isOpen={showPaywall}
+          onClose={() => setShowPaywall(false)}
+          returnTo={`/motion/${motionId}/edit/${totalSteps}`}
         />
       </div>
     </div>

--- a/frontend/src/components/motion/MotionPreview.tsx
+++ b/frontend/src/components/motion/MotionPreview.tsx
@@ -6,6 +6,9 @@ import { format } from 'date-fns';
 import { MotionPreviewBanners, FactCheck } from './MotionPreviewBanners';
 import { MotionPreviewDeclaration } from './MotionPreviewDeclaration';
 import { FilingChecklist } from './FilingChecklist';
+import { downloadBlob } from '../../utils/downloadBlob';
+import { isPaywallError } from '../../services/billing';
+import { PaywallModal } from '../billing/PaywallModal';
 
 interface MotionDraft {
   step_number: number;
@@ -46,6 +49,7 @@ export const MotionPreview: React.FC = () => {
   const [generating, setGenerating] = useState(false);
   const [pdfDownloaded, setPdfDownloaded] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
+  const [showPaywall, setShowPaywall] = useState(false);
 
   const llmFailed = locationState?.llmFailed === true;
   const hasLLMContent = drafts.some((draft) => !!draft.llm_output);
@@ -92,20 +96,14 @@ export const MotionPreview: React.FC = () => {
       setPdfError(null);
 
       const pdfBuffer = await documentAPI.generatePDFSync(motionId!);
-      const blob = new Blob([pdfBuffer], { type: 'application/pdf' });
-      const url = window.URL.createObjectURL(blob);
-
       const filename = `${motion?.motion_type || 'motion'}-${motion?.case_number || 'draft'}.pdf`;
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
+      downloadBlob(pdfBuffer, 'application/pdf', filename);
       setPdfDownloaded(true);
     } catch (error) {
+      if (isPaywallError(error)) {
+        setShowPaywall(true);
+        return;
+      }
       console.error('Failed to generate PDF:', error);
       setPdfError(
         'PDF generation failed. Your draft is saved on our servers — try again or come back later.'
@@ -290,6 +288,12 @@ export const MotionPreview: React.FC = () => {
             </div>
           </div>
         </div>
+
+        <PaywallModal
+          isOpen={showPaywall}
+          onClose={() => setShowPaywall(false)}
+          returnTo={`/motion/${motionId}/preview`}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/motion/intakeNavigation.ts
+++ b/frontend/src/components/motion/intakeNavigation.ts
@@ -1,0 +1,28 @@
+import { NavigateFunction } from 'react-router-dom';
+
+// Post-intake routing: back to FormExecution when it launched us, else preview
+export function navigateAfterIntake(
+  navigate: NavigateFunction,
+  motionId: string,
+  locationState: any,
+  llmFailed: boolean,
+  onComplete?: (motionId: string) => void
+): void {
+  if (onComplete) {
+    onComplete(motionId);
+  }
+
+  // If launched from FormExecution, navigate back to signal completion.
+  // FormExecution is mounted at /case/forms — there is no /form/execution route.
+  if (locationState?.fromFormExecution) {
+    navigate('/case/forms', {
+      state: {
+        ...locationState,
+        completedFormIndex: locationState.formExecutionFormIndex,
+      },
+    });
+    return;
+  }
+
+  navigate(`/motion/${motionId}/preview`, { state: { llmFailed } });
+}

--- a/frontend/src/services/__tests__/billing.test.ts
+++ b/frontend/src/services/__tests__/billing.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for billing service
+ */
+import mockAxios from '../../__mocks__/axios';
+import { billingAPI, isPaywallError } from '../billing';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('billingAPI', () => {
+  test('getStatus GETs /billing/status', async () => {
+    const payload = { status: 'active', is_entitled: true };
+    mockAxios.get.mockResolvedValueOnce({ data: payload });
+
+    const result = await billingAPI.getStatus();
+
+    expect(mockAxios.get).toHaveBeenCalledWith('/billing/status');
+    expect(result).toEqual(payload);
+  });
+
+  test('createCheckoutSession POSTs return_to', async () => {
+    mockAxios.post.mockResolvedValueOnce({ data: { url: 'https://checkout.stripe.com/x' } });
+
+    const result = await billingAPI.createCheckoutSession('/motion/1/preview');
+
+    expect(mockAxios.post).toHaveBeenCalledWith('/billing/checkout-session', {
+      return_to: '/motion/1/preview',
+    });
+    expect(result.url).toBe('https://checkout.stripe.com/x');
+  });
+
+  test('createCheckoutSession without returnTo sends null', async () => {
+    mockAxios.post.mockResolvedValueOnce({ data: { url: 'u' } });
+
+    await billingAPI.createCheckoutSession();
+
+    expect(mockAxios.post).toHaveBeenCalledWith('/billing/checkout-session', {
+      return_to: null,
+    });
+  });
+
+  test('createPortalSession POSTs /billing/portal-session', async () => {
+    mockAxios.post.mockResolvedValueOnce({ data: { url: 'https://billing.stripe.com/x' } });
+
+    const result = await billingAPI.createPortalSession();
+
+    expect(mockAxios.post).toHaveBeenCalledWith('/billing/portal-session');
+    expect(result.url).toBe('https://billing.stripe.com/x');
+  });
+
+  test('verifySession POSTs session_id', async () => {
+    mockAxios.post.mockResolvedValueOnce({ data: { status: 'active', is_entitled: true } });
+
+    const result = await billingAPI.verifySession('cs_123');
+
+    expect(mockAxios.post).toHaveBeenCalledWith('/billing/verify-session', {
+      session_id: 'cs_123',
+    });
+    expect(result.is_entitled).toBe(true);
+  });
+});
+
+describe('isPaywallError', () => {
+  test('true for 402 responses', () => {
+    expect(isPaywallError({ response: { status: 402 } })).toBe(true);
+  });
+
+  test('false for other statuses and shapes', () => {
+    expect(isPaywallError({ response: { status: 500 } })).toBe(false);
+    expect(isPaywallError({})).toBe(false);
+    expect(isPaywallError(undefined)).toBe(false);
+    expect(isPaywallError(new Error('network'))).toBe(false);
+  });
+});

--- a/frontend/src/services/billing.ts
+++ b/frontend/src/services/billing.ts
@@ -1,0 +1,38 @@
+import api from './api';
+
+export interface BillingStatus {
+  status: string | null;
+  is_entitled: boolean;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+}
+
+export const billingAPI = {
+  getStatus: async (): Promise<BillingStatus> => {
+    const response = await api.get('/billing/status');
+    return response.data;
+  },
+
+  createCheckoutSession: async (returnTo?: string): Promise<{ url: string }> => {
+    const response = await api.post('/billing/checkout-session', {
+      return_to: returnTo ?? null,
+    });
+    return response.data;
+  },
+
+  createPortalSession: async (): Promise<{ url: string }> => {
+    const response = await api.post('/billing/portal-session');
+    return response.data;
+  },
+
+  verifySession: async (sessionId: string): Promise<BillingStatus> => {
+    const response = await api.post('/billing/verify-session', {
+      session_id: sessionId,
+    });
+    return response.data;
+  },
+};
+
+// 402 from a gated endpoint means "show the paywall", not "show an error".
+// Works for arraybuffer responses too — status survives any responseType.
+export const isPaywallError = (error: any): boolean => error?.response?.status === 402;

--- a/frontend/src/utils/downloadBlob.ts
+++ b/frontend/src/utils/downloadBlob.ts
@@ -1,0 +1,12 @@
+// Trigger a browser download for an in-memory buffer
+export function downloadBlob(buffer: ArrayBuffer, mimeType: string, filename: string): void {
+  const blob = new Blob([buffer], { type: mimeType });
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ aiosqlite==0.20.0
 pydantic-settings==2.1.0
 greenlet==3.0.3
 anthropic==0.109.1
+stripe~=15.3
 
 google-auth-oauthlib==1.4.0
 google-api-python-client==2.197.0

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,21 +5,38 @@ Decisions: $300 recurring every 3/6 months (interval set in Stripe dashboard via
 paywall gates LLM drafting + PDF export (intake/gameplan/evidence free); hosted Checkout + customer
 portal; 60-day money-back guarantee in offer copy (refunds manual via dashboard); guided-session
 booking via external link (REACT_APP_SCHEDULING_URL). Branch: feat/stripe-billing.
-- [ ] S1 chore(billing): stripe~=15.3 dep, BILLING_ENABLED=false in conftest, this checklist
-- [ ] S2 feat(billing): Subscription model (app/models/subscription.py) + registrations
-- [ ] S3 feat(billing): config settings (STRIPE_* keys, FRONTEND_URL)
-- [ ] S4 feat(billing): 402 gate (app/core/entitlements.py) on llm.py router, documents.py
-      generate-pdf/-sync + /download, chat_pdf.py generate-pdf + complete-workflow
-- [ ] S5 feat(billing): stripe_service.py — customer/checkout/portal/verify + idempotent
-      webhook event application (last_event_created guard)
-- [ ] S6 feat(billing): billing endpoints (checkout-session, portal-session, status, verify-session)
-- [ ] S7 feat(billing): POST /webhooks/stripe with signature verification (unauthenticated)
-- [ ] S8 feat(billing): frontend billing.ts service + isPaywallError
-- [ ] S9 feat(billing): PaywallModal (offer copy incl. 60-day guarantee + session)
-- [ ] S10 feat(billing): GuidedIntake 402 → paywall modal, stop navigation
-- [ ] S11 feat(billing): MotionPreview PDF 402 → paywall modal
-- [ ] S12 feat(billing): BillingSuccess (verify + poll) / BillingCanceled / BillingButton +
-      routes + Dashboard entry; manual Stripe test-mode E2E
+- [x] S1 chore(billing): stripe~=15.3 dep, BILLING_ENABLED=false in conftest (24ac5f7)
+- [x] S2 feat(billing): Subscription model + registrations (f0725c4)
+- [x] S3 feat(billing): config settings STRIPE_* keys, FRONTEND_URL (991e354)
+- [x] S4 feat(billing): 402 gate on llm.py router, documents generate-pdf/-sync + /download,
+      chat_pdf generate-pdf + complete-workflow (d774c0b)
+- [x] S5 feat(billing): stripe_service.py — idempotent webhook application, last_event_created
+      guard, item-level current_period_end fallback for new Stripe API (e85934b)
+- [x] S6 feat(billing): checkout/portal/status/verify endpoints + 10/hr checkout limit (2567939)
+- [x] S7 feat(billing): POST /webhooks/stripe, real-HMAC signature tests. Gotcha: stripe v15
+      StripeObject is not a dict — endpoint passes json.loads(payload) to apply (1f86968)
+- [x] S8 feat(billing): billing.ts + isPaywallError (6030a8c)
+- [x] S9 feat(billing): PaywallModal — $300, 60-day guarantee, 1-on-1 session copy (d417fce)
+- [x] S10 feat(billing): GuidedIntake 402 → modal, returnTo /motion/{id}/edit/{lastStep};
+      extracted intakeNavigation.ts to stay ≤300 (c69ae5b)
+- [x] S11 feat(billing): MotionPreview 402 → modal; extracted utils/downloadBlob.ts (d15a007)
+- [x] S12 feat(billing): BillingSuccess (verify-session + 5×2s status poll + scheduling link),
+      BillingCanceled, BillingButton, /billing/* routes, Dashboard entry (e85169e)
+- [ ] S13 Manual Stripe test-mode E2E — BLOCKED on owner: create test-mode Product/Price
+      ($300 per 3 or 6 months) → STRIPE_PRICE_ID; sk_test key → STRIPE_SECRET_KEY;
+      `stripe listen --forward-to localhost:8000/api/v1/webhooks/stripe` → STRIPE_WEBHOOK_SECRET;
+      set BILLING_ENABLED=true; save default portal config; dunning = cancel after retries fail.
+      Verifies live: #-fragment success_url + {CHECKOUT_SESSION_ID} substitution.
+      NOTE: user pasted a pk_live (publishable) key in chat — not usable server-side and
+      live-mode; need sk_test via env, never in chat/repo.
+
+### Review (2026-07-17)
+Backend 589 passed / 3 xfailed; frontend 43 suites / 280 passed; prod build compiles
+(pre-existing exhaustive-deps warnings only). Gate default: BILLING_ENABLED unset → billing ON
+in prod code path (`getenv("BILLING_ENABLED", "true")`) but conftest forces false for tests —
+deploy must set STRIPE_* secrets or gated endpoints 402 with no way to pay (checkout 503s until
+configured). Entitled statuses: active/trialing/past_due (past_due grace delegated to Stripe
+dunning). Refunds: manual in dashboard; cancel the sub there to revoke access via webhook.
 
 
 ## Model upgrade + LLM checker (2026-07-14, approved: Opus drafter + Opus checker, no Gemini)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,7 +1,9 @@
 # Build Plan — Family Court Helper MVP (formerly California Motion Writer)
 
 ## Stripe subscription billing (2026-07-17, approved plan: ~/.claude/plans/buzzing-nibbling-emerson.md)
-Decisions: $300 recurring every 3/6 months (interval set in Stripe dashboard via STRIPE_PRICE_ID);
+Decisions: PRICING CHANGED 2026-07-17 (superseding the earlier $300/3-6mo choice): $499 one-time
+setup fee + $99/month recurring — checkout carries STRIPE_SETUP_PRICE_ID (one-time) alongside
+STRIPE_PRICE_ID ($99/mo); both required or checkout 503s;
 paywall gates LLM drafting + PDF export (intake/gameplan/evidence free); hosted Checkout + customer
 portal; 60-day money-back guarantee in offer copy (refunds manual via dashboard); guided-session
 booking via external link (REACT_APP_SCHEDULING_URL). Branch: feat/stripe-billing.
@@ -22,8 +24,11 @@ booking via external link (REACT_APP_SCHEDULING_URL). Branch: feat/stripe-billin
 - [x] S11 feat(billing): MotionPreview 402 → modal; extracted utils/downloadBlob.ts (d15a007)
 - [x] S12 feat(billing): BillingSuccess (verify-session + 5×2s status poll + scheduling link),
       BillingCanceled, BillingButton, /billing/* routes, Dashboard entry (e85169e)
-- [ ] S13 Manual Stripe test-mode E2E — BLOCKED on owner: create test-mode Product/Price
-      ($300 per 3 or 6 months) → STRIPE_PRICE_ID; sk_test key → STRIPE_SECRET_KEY;
+- [x] S14 feat(billing): pricing switched to $499 setup + $99/mo (owner decision via
+      AskUserQuestion; checkout line_items + STRIPE_SETUP_PRICE_ID + paywall copy)
+- [ ] S13 Manual Stripe test-mode E2E — BLOCKED on owner: in TEST mode create TWO prices
+      (product prod_Uu9MKcVs5lagnL if it was made in test mode): recurring $99/month →
+      STRIPE_PRICE_ID, one-time $499 → STRIPE_SETUP_PRICE_ID; sk_test key → STRIPE_SECRET_KEY;
       `stripe listen --forward-to localhost:8000/api/v1/webhooks/stripe` → STRIPE_WEBHOOK_SECRET;
       set BILLING_ENABLED=true; save default portal config; dunning = cancel after retries fail.
       Verifies live: #-fragment success_url + {CHECKOUT_SESSION_ID} substitution.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,27 @@
 # Build Plan — Family Court Helper MVP (formerly California Motion Writer)
 
+## Stripe subscription billing (2026-07-17, approved plan: ~/.claude/plans/buzzing-nibbling-emerson.md)
+Decisions: $300 recurring every 3/6 months (interval set in Stripe dashboard via STRIPE_PRICE_ID);
+paywall gates LLM drafting + PDF export (intake/gameplan/evidence free); hosted Checkout + customer
+portal; 60-day money-back guarantee in offer copy (refunds manual via dashboard); guided-session
+booking via external link (REACT_APP_SCHEDULING_URL). Branch: feat/stripe-billing.
+- [ ] S1 chore(billing): stripe~=15.3 dep, BILLING_ENABLED=false in conftest, this checklist
+- [ ] S2 feat(billing): Subscription model (app/models/subscription.py) + registrations
+- [ ] S3 feat(billing): config settings (STRIPE_* keys, FRONTEND_URL)
+- [ ] S4 feat(billing): 402 gate (app/core/entitlements.py) on llm.py router, documents.py
+      generate-pdf/-sync + /download, chat_pdf.py generate-pdf + complete-workflow
+- [ ] S5 feat(billing): stripe_service.py — customer/checkout/portal/verify + idempotent
+      webhook event application (last_event_created guard)
+- [ ] S6 feat(billing): billing endpoints (checkout-session, portal-session, status, verify-session)
+- [ ] S7 feat(billing): POST /webhooks/stripe with signature verification (unauthenticated)
+- [ ] S8 feat(billing): frontend billing.ts service + isPaywallError
+- [ ] S9 feat(billing): PaywallModal (offer copy incl. 60-day guarantee + session)
+- [ ] S10 feat(billing): GuidedIntake 402 → paywall modal, stop navigation
+- [ ] S11 feat(billing): MotionPreview PDF 402 → paywall modal
+- [ ] S12 feat(billing): BillingSuccess (verify + poll) / BillingCanceled / BillingButton +
+      routes + Dashboard entry; manual Stripe test-mode E2E
+
+
 ## Model upgrade + LLM checker (2026-07-14, approved: Opus drafter + Opus checker, no Gemini)
 - [x] U1 feat(llm): drafting tier Sonnet 4.6 → Opus 4.8 (1ff81b6) — live-verified, drafts
       carry claude-opus-4-8, ~54s per motion (comparable to Sonnet)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -26,14 +26,19 @@ booking via external link (REACT_APP_SCHEDULING_URL). Branch: feat/stripe-billin
       BillingCanceled, BillingButton, /billing/* routes, Dashboard entry (e85169e)
 - [x] S14 feat(billing): pricing switched to $499 setup + $99/mo (owner decision via
       AskUserQuestion; checkout line_items + STRIPE_SETUP_PRICE_ID + paywall copy)
-- [ ] S13 Manual Stripe test-mode E2E — BLOCKED on owner: in TEST mode create TWO prices
-      (product prod_Uu9MKcVs5lagnL if it was made in test mode): recurring $99/month →
-      STRIPE_PRICE_ID, one-time $499 → STRIPE_SETUP_PRICE_ID; sk_test key → STRIPE_SECRET_KEY;
-      `stripe listen --forward-to localhost:8000/api/v1/webhooks/stripe` → STRIPE_WEBHOOK_SECRET;
-      set BILLING_ENABLED=true; save default portal config; dunning = cancel after retries fail.
-      Verifies live: #-fragment success_url + {CHECKOUT_SESSION_ID} substitution.
-      NOTE: user pasted a pk_live (publishable) key in chat — not usable server-side and
-      live-mode; need sk_test via env, never in chat/repo.
+- [x] S13 Stripe test-mode E2E PASSED 2026-07-18: 402 pre-pay → checkout session ($499+$99
+      line items, correct #-fragment success_url) → test-card payment ($598.00 first invoice,
+      paid) → webhook unlock in ~1s (status active, period end +1mo) → drafting 200 → portal
+      URL ok → API cancel → webhook re-lock in ~1s → 402. Rig: backend uvicorn :8001 (:8000
+      is another project's Docker), stripe listen via docker stripe/stripe-cli (CLI install
+      via brew blocked by outdated Xcode CLT). Owner's product/prices were made in LIVE mode;
+      test-mode copies created via API (prod_UuYYaljrKDs4xh). LIVE ids preserved in .env
+      comments: $499 price_1TuL3yDMovrH2tcZ9Nz49B2o, $99/mo price_1TuPTCDMovrH2tcZvfgY5r6J.
+- [ ] S15 Go-live checklist (deploy-time): swap sk_live + LIVE price ids into Secret Manager;
+      register https://<prod-domain>/api/v1/webhooks/stripe in the LIVE dashboard → whsec into
+      Secret Manager; save LIVE customer-portal default config; set LIVE dunning to cancel
+      subscription after failed retries; set FRONTEND_URL to prod URL. Optional: browser
+      click-through of checkout (visual confirmation of redirect substitution).
 
 ### Review (2026-07-17)
 Backend 589 passed / 3 xfailed; frontend 43 suites / 280 passed; prod build compiles

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ os.environ["USE_MOCK_LLM"] = "true"
 os.environ["SECRET_KEY"] = "test-secret-key-for-testing"
 # Off by default: the shared-IP auth fixture would trip auth limits mid-suite
 os.environ["RATE_LIMIT_ENABLED"] = "false"
+# Off by default: billing gate would 402 the existing LLM/PDF tests
+os.environ["BILLING_ENABLED"] = "false"
 
 # Add app to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from app.models.profile import Profile
 from app.models.motion import Motion
 from app.models.chat import ChatSession, ChatMessage
 from app.models.evidence import Evidence
+from app.models.subscription import Subscription
 
 from app.api.v1.endpoints.auth import get_password_hash
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,34 @@ async def client() -> AsyncGenerator[AsyncClient, None]:
     await engine.dispose()
 
 @pytest_asyncio.fixture
+async def client_with_db():
+    """Client plus a session maker into the same in-memory DB, for tests that
+    must insert rows (e.g. subscriptions) for API-registered users."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False
+    )
+
+    async def override_get_db():
+        async with session_maker() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, session_maker
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+@pytest_asyncio.fixture
 async def test_user(test_db: AsyncSession) -> User:
     """Create a test user."""
     user = User(

--- a/tests/test_billing_config.py
+++ b/tests/test_billing_config.py
@@ -1,0 +1,11 @@
+"""
+Tests for Stripe billing settings
+"""
+from app.core.config import settings
+
+
+def test_stripe_settings_have_safe_defaults():
+    assert settings.STRIPE_SECRET_KEY == ""
+    assert settings.STRIPE_WEBHOOK_SECRET == ""
+    assert settings.STRIPE_PRICE_ID == ""
+    assert settings.FRONTEND_URL == "http://localhost:3000"

--- a/tests/test_billing_config.py
+++ b/tests/test_billing_config.py
@@ -8,4 +8,5 @@ def test_stripe_settings_have_safe_defaults():
     assert settings.STRIPE_SECRET_KEY == ""
     assert settings.STRIPE_WEBHOOK_SECRET == ""
     assert settings.STRIPE_PRICE_ID == ""
+    assert settings.STRIPE_SETUP_PRICE_ID == ""
     assert settings.FRONTEND_URL == "http://localhost:3000"

--- a/tests/test_billing_endpoints.py
+++ b/tests/test_billing_endpoints.py
@@ -1,0 +1,175 @@
+"""
+Billing endpoints: checkout-session, portal-session, status, verify-session
+"""
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.models.subscription import Subscription
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register_and_login(client: AsyncClient) -> dict:
+    await client.post("/api/v1/auth/register", json={
+        "email": "payer@example.com",
+        "password": "payerpass123",
+        "full_name": "Payer User",
+    })
+    response = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "payer@example.com", "password": "payerpass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+async def _user_id(session_maker) -> str:
+    async with session_maker() as session:
+        result = await session.execute(select(User).where(User.email == "payer@example.com"))
+        return str(result.scalar_one().id)
+
+
+async def _add_subscription(session_maker, status="active", **kwargs):
+    async with session_maker() as session:
+        result = await session.execute(select(User).where(User.email == "payer@example.com"))
+        user = result.scalar_one()
+        session.add(Subscription(
+            user_id=user.id,
+            stripe_customer_id=kwargs.pop("stripe_customer_id", "cus_1"),
+            status=status,
+            **kwargs,
+        ))
+        await session.commit()
+
+
+@pytest.mark.parametrize("method,path", [
+    ("post", "/api/v1/billing/checkout-session"),
+    ("post", "/api/v1/billing/portal-session"),
+    ("get", "/api/v1/billing/status"),
+    ("post", "/api/v1/billing/verify-session"),
+])
+async def test_billing_requires_auth(client_with_db, method, path):
+    client, _ = client_with_db
+    response = await getattr(client, method)(path)
+    assert response.status_code == 401
+
+
+async def test_checkout_session_returns_url(client_with_db, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
+    monkeypatch.setattr(settings, "STRIPE_PRICE_ID", "price_test")
+    client, _ = client_with_db
+    headers = await _register_and_login(client)
+    with patch("app.services.stripe_service.stripe.Customer.create") as cus, \
+         patch("app.services.stripe_service.stripe.checkout.Session.create") as ses:
+        cus.return_value = {"id": "cus_new"}
+        ses.return_value = {"url": "https://checkout.stripe.com/c/pay/x"}
+        response = await client.post(
+            "/api/v1/billing/checkout-session",
+            headers=headers,
+            json={"return_to": "/motion/1/preview"},
+        )
+    assert response.status_code == 200
+    assert response.json() == {"url": "https://checkout.stripe.com/c/pay/x"}
+
+
+async def test_checkout_session_503_when_unconfigured(client_with_db):
+    # settings default STRIPE_SECRET_KEY is "" in tests
+    client, _ = client_with_db
+    headers = await _register_and_login(client)
+    response = await client.post("/api/v1/billing/checkout-session", headers=headers, json={})
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "billing_not_configured"
+
+
+async def test_portal_session_404_without_subscription(client_with_db, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
+    client, _ = client_with_db
+    headers = await _register_and_login(client)
+    response = await client.post("/api/v1/billing/portal-session", headers=headers)
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "no_subscription"
+
+
+async def test_portal_session_returns_url(client_with_db, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
+    client, session_maker = client_with_db
+    headers = await _register_and_login(client)
+    await _add_subscription(session_maker)
+    with patch("app.services.stripe_service.stripe.billing_portal.Session.create") as ses:
+        ses.return_value = {"url": "https://billing.stripe.com/p/session/x"}
+        response = await client.post("/api/v1/billing/portal-session", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"url": "https://billing.stripe.com/p/session/x"}
+
+
+async def test_status_no_subscription(client_with_db):
+    client, _ = client_with_db
+    headers = await _register_and_login(client)
+    response = await client.get("/api/v1/billing/status", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": None,
+        "is_entitled": False,
+        "current_period_end": None,
+        "cancel_at_period_end": False,
+    }
+
+
+@pytest.mark.parametrize("status,entitled", [("active", True), ("canceled", False)])
+async def test_status_reflects_subscription(client_with_db, status, entitled):
+    client, session_maker = client_with_db
+    headers = await _register_and_login(client)
+    await _add_subscription(session_maker, status=status)
+    response = await client.get("/api/v1/billing/status", headers=headers)
+    body = response.json()
+    assert body["status"] == status
+    assert body["is_entitled"] is entitled
+
+
+async def test_verify_session_syncs_subscription(client_with_db, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
+    client, session_maker = client_with_db
+    headers = await _register_and_login(client)
+    await _add_subscription(session_maker, status="incomplete")
+    user_id = await _user_id(session_maker)
+    with patch("app.services.stripe_service.stripe.checkout.Session.retrieve") as ses, \
+         patch("app.services.stripe_service.stripe.Subscription.retrieve") as sub:
+        ses.return_value = {
+            "id": "cs_1",
+            "customer": "cus_1",
+            "subscription": "sub_1",
+            "client_reference_id": user_id,
+        }
+        sub.return_value = {
+            "id": "sub_1",
+            "customer": "cus_1",
+            "status": "active",
+            "current_period_end": 1893456000,
+            "cancel_at_period_end": False,
+            "items": {"data": [{"price": {"id": "price_test"}}]},
+        }
+        response = await client.post(
+            "/api/v1/billing/verify-session", headers=headers, json={"session_id": "cs_1"}
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "active"
+    assert body["is_entitled"] is True
+
+
+async def test_verify_session_rejects_foreign_session(client_with_db, monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
+    client, _ = client_with_db
+    headers = await _register_and_login(client)
+    with patch("app.services.stripe_service.stripe.checkout.Session.retrieve") as ses:
+        ses.return_value = {"id": "cs_1", "client_reference_id": "someone-else"}
+        response = await client.post(
+            "/api/v1/billing/verify-session", headers=headers, json={"session_id": "cs_1"}
+        )
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "session_ownership_mismatch"

--- a/tests/test_billing_endpoints.py
+++ b/tests/test_billing_endpoints.py
@@ -62,6 +62,7 @@ async def test_billing_requires_auth(client_with_db, method, path):
 async def test_checkout_session_returns_url(client_with_db, monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
     monkeypatch.setattr(settings, "STRIPE_PRICE_ID", "price_test")
+    monkeypatch.setattr(settings, "STRIPE_SETUP_PRICE_ID", "price_setup")
     client, _ = client_with_db
     headers = await _register_and_login(client)
     with patch("app.services.stripe_service.stripe.Customer.create") as cus, \

--- a/tests/test_billing_gate.py
+++ b/tests/test_billing_gate.py
@@ -3,13 +3,9 @@ Entitlement gate: LLM drafting and PDF export require an active subscription
 (402 subscription_required) when BILLING_ENABLED=true.
 """
 import pytest
-import pytest_asyncio
-from httpx import AsyncClient, ASGITransport
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from httpx import AsyncClient
 from sqlalchemy import select
 
-from app.main import app
-from app.core.database import Base, get_db
 from app.core.entitlements import is_entitled
 from app.models.subscription import Subscription
 from app.models.user import User
@@ -17,27 +13,6 @@ from app.models.user import User
 pytestmark = pytest.mark.asyncio
 
 REWRITE_BODY = {"motion_type": "RFO", "section": "facts", "user_input": "test input"}
-
-
-@pytest_asyncio.fixture
-async def billing_client():
-    """Client plus a session maker into the same in-memory DB, so tests can
-    insert subscription rows for API-registered users."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-
-    async def override_get_db():
-        async with session_maker() as session:
-            yield session
-
-    app.dependency_overrides[get_db] = override_get_db
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac, session_maker
-    app.dependency_overrides.clear()
-    await engine.dispose()
 
 
 async def _register_and_login(client: AsyncClient) -> dict:
@@ -93,9 +68,9 @@ GATED_CALLS = [
 
 
 @pytest.mark.parametrize("method,path,body", GATED_CALLS)
-async def test_unsubscribed_user_gets_402(billing_client, monkeypatch, method, path, body):
+async def test_unsubscribed_user_gets_402(client_with_db, monkeypatch, method, path, body):
     monkeypatch.setenv("BILLING_ENABLED", "true")
-    client, _ = billing_client
+    client, _ = client_with_db
     headers = await _register_and_login(client)
     kwargs = {"headers": headers} if body is None else {"headers": headers, "json": body}
     response = await getattr(client, method)(path, **kwargs)
@@ -103,27 +78,27 @@ async def test_unsubscribed_user_gets_402(billing_client, monkeypatch, method, p
     assert response.json()["detail"]["code"] == "subscription_required"
 
 
-async def test_active_subscription_passes_gate(billing_client, monkeypatch):
+async def test_active_subscription_passes_gate(client_with_db, monkeypatch):
     monkeypatch.setenv("BILLING_ENABLED", "true")
-    client, session_maker = billing_client
+    client, session_maker = client_with_db
     headers = await _register_and_login(client)
     await _set_subscription(session_maker, "active")
     response = await client.post("/api/v1/llm/rewrite", headers=headers, json=REWRITE_BODY)
     assert response.status_code != 402
 
 
-async def test_canceled_subscription_gets_402(billing_client, monkeypatch):
+async def test_canceled_subscription_gets_402(client_with_db, monkeypatch):
     monkeypatch.setenv("BILLING_ENABLED", "true")
-    client, session_maker = billing_client
+    client, session_maker = client_with_db
     headers = await _register_and_login(client)
     await _set_subscription(session_maker, "canceled")
     response = await client.post("/api/v1/llm/rewrite", headers=headers, json=REWRITE_BODY)
     assert response.status_code == 402
 
 
-async def test_gate_disabled_by_default_flag(billing_client):
+async def test_gate_disabled_by_default_flag(client_with_db):
     # conftest sets BILLING_ENABLED=false — existing behavior is untouched
-    client, _ = billing_client
+    client, _ = client_with_db
     headers = await _register_and_login(client)
     response = await client.post("/api/v1/llm/rewrite", headers=headers, json=REWRITE_BODY)
     assert response.status_code != 402

--- a/tests/test_billing_gate.py
+++ b/tests/test_billing_gate.py
@@ -1,0 +1,129 @@
+"""
+Entitlement gate: LLM drafting and PDF export require an active subscription
+(402 subscription_required) when BILLING_ENABLED=true.
+"""
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy import select
+
+from app.main import app
+from app.core.database import Base, get_db
+from app.core.entitlements import is_entitled
+from app.models.subscription import Subscription
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+REWRITE_BODY = {"motion_type": "RFO", "section": "facts", "user_input": "test input"}
+
+
+@pytest_asyncio.fixture
+async def billing_client():
+    """Client plus a session maker into the same in-memory DB, so tests can
+    insert subscription rows for API-registered users."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_maker() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, session_maker
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+async def _register_and_login(client: AsyncClient) -> dict:
+    await client.post("/api/v1/auth/register", json={
+        "email": "payer@example.com",
+        "password": "payerpass123",
+        "full_name": "Payer User",
+    })
+    response = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "payer@example.com", "password": "payerpass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+async def _set_subscription(session_maker, status: str):
+    async with session_maker() as session:
+        result = await session.execute(
+            select(User).where(User.email == "payer@example.com")
+        )
+        user = result.scalar_one()
+        existing = (
+            await session.execute(
+                select(Subscription).where(Subscription.user_id == user.id)
+            )
+        ).scalar_one_or_none()
+        if existing:
+            existing.status = status
+        else:
+            session.add(
+                Subscription(user_id=user.id, stripe_customer_id="cus_test", status=status)
+            )
+        await session.commit()
+
+
+def test_is_entitled_truth_table():
+    assert is_entitled(None) is False
+    for status in ("incomplete", "canceled", "unpaid", "incomplete_expired", "paused"):
+        assert is_entitled(Subscription(status=status)) is False, status
+    for status in ("active", "trialing", "past_due"):
+        assert is_entitled(Subscription(status=status)) is True, status
+
+
+GATED_CALLS = [
+    ("post", "/api/v1/llm/rewrite", REWRITE_BODY),
+    ("post", "/api/v1/documents/generate-pdf-sync", {"motion_id": "00000000-0000-0000-0000-000000000000"}),
+    ("post", "/api/v1/documents/generate-pdf", {"motion_id": "00000000-0000-0000-0000-000000000000"}),
+    ("get", "/api/v1/documents/00000000-0000-0000-0000-000000000000/download", None),
+    ("post", "/api/v1/chat-pdf/generate-pdf", {"motion_id": "00000000-0000-0000-0000-000000000000"}),
+    ("post", "/api/v1/chat-pdf/complete-workflow", {"session_id": "s1"}),
+]
+
+
+@pytest.mark.parametrize("method,path,body", GATED_CALLS)
+async def test_unsubscribed_user_gets_402(billing_client, monkeypatch, method, path, body):
+    monkeypatch.setenv("BILLING_ENABLED", "true")
+    client, _ = billing_client
+    headers = await _register_and_login(client)
+    kwargs = {"headers": headers} if body is None else {"headers": headers, "json": body}
+    response = await getattr(client, method)(path, **kwargs)
+    assert response.status_code == 402
+    assert response.json()["detail"]["code"] == "subscription_required"
+
+
+async def test_active_subscription_passes_gate(billing_client, monkeypatch):
+    monkeypatch.setenv("BILLING_ENABLED", "true")
+    client, session_maker = billing_client
+    headers = await _register_and_login(client)
+    await _set_subscription(session_maker, "active")
+    response = await client.post("/api/v1/llm/rewrite", headers=headers, json=REWRITE_BODY)
+    assert response.status_code != 402
+
+
+async def test_canceled_subscription_gets_402(billing_client, monkeypatch):
+    monkeypatch.setenv("BILLING_ENABLED", "true")
+    client, session_maker = billing_client
+    headers = await _register_and_login(client)
+    await _set_subscription(session_maker, "canceled")
+    response = await client.post("/api/v1/llm/rewrite", headers=headers, json=REWRITE_BODY)
+    assert response.status_code == 402
+
+
+async def test_gate_disabled_by_default_flag(billing_client):
+    # conftest sets BILLING_ENABLED=false — existing behavior is untouched
+    client, _ = billing_client
+    headers = await _register_and_login(client)
+    response = await client.post("/api/v1/llm/rewrite", headers=headers, json=REWRITE_BODY)
+    assert response.status_code != 402

--- a/tests/test_billing_model.py
+++ b/tests/test_billing_model.py
@@ -1,0 +1,66 @@
+"""
+Tests for the Subscription model
+"""
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.subscription import Subscription
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_subscription_defaults(test_db: AsyncSession, test_user: User):
+    sub = Subscription(user_id=test_user.id, stripe_customer_id="cus_123")
+    test_db.add(sub)
+    await test_db.commit()
+    await test_db.refresh(sub)
+
+    assert sub.id is not None
+    assert sub.status == "incomplete"
+    assert sub.stripe_subscription_id is None
+    assert sub.price_id is None
+    assert sub.current_period_end is None
+    assert sub.cancel_at_period_end is False
+    assert sub.last_event_created is None
+    assert sub.created_at is not None
+    assert sub.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_one_subscription_per_user(test_db: AsyncSession, test_user: User):
+    test_db.add(Subscription(user_id=test_user.id, stripe_customer_id="cus_1"))
+    await test_db.commit()
+
+    test_db.add(Subscription(user_id=test_user.id, stripe_customer_id="cus_2"))
+    with pytest.raises(IntegrityError):
+        await test_db.commit()
+    await test_db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_stripe_subscription_id_unique(test_db: AsyncSession, test_user: User):
+    other = User(
+        email="other@example.com",
+        password_hash="x",
+        full_name="Other User",
+    )
+    test_db.add(other)
+    await test_db.commit()
+    await test_db.refresh(other)
+
+    test_db.add(
+        Subscription(
+            user_id=test_user.id, stripe_customer_id="cus_1", stripe_subscription_id="sub_1"
+        )
+    )
+    await test_db.commit()
+
+    test_db.add(
+        Subscription(
+            user_id=other.id, stripe_customer_id="cus_2", stripe_subscription_id="sub_1"
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await test_db.commit()
+    await test_db.rollback()

--- a/tests/test_stripe_service.py
+++ b/tests/test_stripe_service.py
@@ -1,0 +1,197 @@
+"""
+Stripe service: customer creation, checkout URL building, and idempotent
+webhook event application
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.subscription import Subscription
+from app.models.user import User
+from app.services.stripe_service import (
+    apply_stripe_event,
+    create_checkout_session,
+    get_or_create_customer,
+)
+
+pytestmark = pytest.mark.asyncio
+
+PERIOD_END = 1893456000  # 2030-01-01
+
+
+@pytest.fixture
+def stripe_key(monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
+    monkeypatch.setattr(settings, "STRIPE_PRICE_ID", "price_test")
+
+
+def _sub_object(status="active", customer="cus_1", sub_id="sub_1", cancel=False):
+    return {
+        "id": sub_id,
+        "customer": customer,
+        "status": status,
+        "current_period_end": PERIOD_END,
+        "cancel_at_period_end": cancel,
+        "items": {"data": [{"price": {"id": "price_test"}}]},
+    }
+
+
+def _sub_event(etype="customer.subscription.updated", created=100, **kwargs):
+    return {"type": etype, "created": created, "data": {"object": _sub_object(**kwargs)}}
+
+
+async def _make_row(test_db, test_user, **kwargs) -> Subscription:
+    row = Subscription(
+        user_id=test_user.id, stripe_customer_id=kwargs.pop("stripe_customer_id", "cus_1"), **kwargs
+    )
+    test_db.add(row)
+    await test_db.commit()
+    await test_db.refresh(row)
+    return row
+
+
+async def test_get_or_create_customer_creates_once(
+    test_db: AsyncSession, test_user: User, stripe_key
+):
+    with patch("app.services.stripe_service.stripe.Customer.create") as create:
+        create.return_value = {"id": "cus_new"}
+        first = await get_or_create_customer(test_db, test_user)
+        second = await get_or_create_customer(test_db, test_user)
+
+    assert create.call_count == 1
+    assert first.stripe_customer_id == "cus_new"
+    assert first.status == "incomplete"
+    assert second.id == first.id
+
+
+async def test_create_checkout_session_builds_urls(
+    test_db: AsyncSession, test_user: User, stripe_key
+):
+    await _make_row(test_db, test_user)
+    with patch("app.services.stripe_service.stripe.checkout.Session.create") as create:
+        create.return_value = {"url": "https://checkout.stripe.com/c/pay/x"}
+        url = await create_checkout_session(test_db, test_user, "/motion/1/preview")
+
+    assert url == "https://checkout.stripe.com/c/pay/x"
+    kwargs = create.call_args.kwargs
+    assert kwargs["mode"] == "subscription"
+    assert kwargs["customer"] == "cus_1"
+    assert kwargs["client_reference_id"] == str(test_user.id)
+    assert kwargs["line_items"] == [{"price": "price_test", "quantity": 1}]
+    assert "#/billing/success?session_id={CHECKOUT_SESSION_ID}" in kwargs["success_url"]
+    assert "return_to=/motion/1/preview" in kwargs["success_url"]
+    assert kwargs["cancel_url"].endswith("#/billing/canceled")
+
+
+@pytest.mark.parametrize("bad", ["//evil.com", "https://evil.com", "javascript:x"])
+async def test_checkout_return_to_sanitized(
+    test_db: AsyncSession, test_user: User, stripe_key, bad
+):
+    await _make_row(test_db, test_user)
+    with patch("app.services.stripe_service.stripe.checkout.Session.create") as create:
+        create.return_value = {"url": "https://checkout.stripe.com/c/pay/x"}
+        await create_checkout_session(test_db, test_user, bad)
+    assert "return_to=/dashboard" in create.call_args.kwargs["success_url"]
+
+
+async def test_subscription_updated_snapshots_row(test_db: AsyncSession, test_user: User):
+    await _make_row(test_db, test_user)
+    await apply_stripe_event(test_db, _sub_event(created=100, cancel=True))
+
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.status == "active"
+    assert row.stripe_subscription_id == "sub_1"
+    assert row.price_id == "price_test"
+    assert row.cancel_at_period_end is True
+    assert row.current_period_end == datetime.fromtimestamp(PERIOD_END, tz=timezone.utc).replace(
+        tzinfo=row.current_period_end.tzinfo
+    )
+    assert row.last_event_created == 100
+
+
+async def test_subscription_deleted_marks_canceled(test_db: AsyncSession, test_user: User):
+    await _make_row(test_db, test_user, status="active")
+    await apply_stripe_event(
+        test_db, _sub_event("customer.subscription.deleted", created=200, status="canceled")
+    )
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.status == "canceled"
+
+
+async def test_invoice_payment_failed_sets_past_due(test_db: AsyncSession, test_user: User):
+    await _make_row(test_db, test_user, status="active")
+    event = {
+        "type": "invoice.payment_failed",
+        "created": 300,
+        "data": {"object": {"customer": "cus_1", "subscription": "sub_1"}},
+    }
+    await apply_stripe_event(test_db, event)
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.status == "past_due"
+
+
+async def test_checkout_completed_links_and_retrieves(
+    test_db: AsyncSession, test_user: User, stripe_key
+):
+    await _make_row(test_db, test_user)
+    event = {
+        "type": "checkout.session.completed",
+        "created": 400,
+        "data": {
+            "object": {
+                "id": "cs_1",
+                "customer": "cus_1",
+                "subscription": "sub_9",
+                "client_reference_id": str(test_user.id),
+            }
+        },
+    }
+    with patch("app.services.stripe_service.stripe.Subscription.retrieve") as retrieve:
+        retrieve.return_value = _sub_object(sub_id="sub_9")
+        await apply_stripe_event(test_db, event)
+
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.stripe_subscription_id == "sub_9"
+    assert row.status == "active"
+
+
+async def test_replay_same_event_is_noop(test_db: AsyncSession, test_user: User):
+    await _make_row(test_db, test_user)
+    event = _sub_event(created=500)
+    await apply_stripe_event(test_db, event)
+    await apply_stripe_event(test_db, event)
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.status == "active"
+    assert row.last_event_created == 500
+
+
+async def test_stale_older_event_skipped(test_db: AsyncSession, test_user: User):
+    await _make_row(test_db, test_user)
+    await apply_stripe_event(test_db, _sub_event(created=600, status="canceled"))
+    await apply_stripe_event(test_db, _sub_event(created=550, status="active"))
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.status == "canceled"
+    assert row.last_event_created == 600
+
+
+async def test_unknown_customer_tolerated(test_db: AsyncSession, test_user: User):
+    # No row exists at all — must not raise (webhook returns 200 so Stripe stops retrying)
+    await apply_stripe_event(test_db, _sub_event(customer="cus_nobody"))
+    assert (await test_db.execute(select(Subscription))).scalar_one_or_none() is None
+
+
+async def test_period_end_item_level_fallback(test_db: AsyncSession, test_user: User):
+    # Stripe API >= 2025-03-31 moved current_period_end onto the item
+    await _make_row(test_db, test_user)
+    obj = _sub_object()
+    del obj["current_period_end"]
+    obj["items"]["data"][0]["current_period_end"] = PERIOD_END
+    await apply_stripe_event(
+        test_db, {"type": "customer.subscription.updated", "created": 700, "data": {"object": obj}}
+    )
+    row = (await test_db.execute(select(Subscription))).scalar_one()
+    assert row.current_period_end is not None

--- a/tests/test_stripe_service.py
+++ b/tests/test_stripe_service.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +28,7 @@ PERIOD_END = 1893456000  # 2030-01-01
 def stripe_key(monkeypatch):
     monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "sk_test_key")
     monkeypatch.setattr(settings, "STRIPE_PRICE_ID", "price_test")
+    monkeypatch.setattr(settings, "STRIPE_SETUP_PRICE_ID", "price_setup")
 
 
 def _sub_object(status="active", customer="cus_1", sub_id="sub_1", cancel=False):
@@ -81,10 +83,25 @@ async def test_create_checkout_session_builds_urls(
     assert kwargs["mode"] == "subscription"
     assert kwargs["customer"] == "cus_1"
     assert kwargs["client_reference_id"] == str(test_user.id)
-    assert kwargs["line_items"] == [{"price": "price_test", "quantity": 1}]
+    # One-time $499 setup fee joins the first invoice; $99/mo price defines the subscription
+    assert kwargs["line_items"] == [
+        {"price": "price_setup", "quantity": 1},
+        {"price": "price_test", "quantity": 1},
+    ]
     assert "#/billing/success?session_id={CHECKOUT_SESSION_ID}" in kwargs["success_url"]
     assert "return_to=/motion/1/preview" in kwargs["success_url"]
     assert kwargs["cancel_url"].endswith("#/billing/canceled")
+
+
+async def test_checkout_503_without_setup_price(
+    test_db: AsyncSession, test_user: User, stripe_key, monkeypatch
+):
+    # Missing setup price would silently sell $99/mo without the $499 — refuse instead
+    monkeypatch.setattr(settings, "STRIPE_SETUP_PRICE_ID", "")
+    await _make_row(test_db, test_user)
+    with pytest.raises(HTTPException) as exc_info:
+        await create_checkout_session(test_db, test_user, "/dashboard")
+    assert exc_info.value.status_code == 503
 
 
 @pytest.mark.parametrize("bad", ["//evil.com", "https://evil.com", "javascript:x"])

--- a/tests/test_stripe_webhook.py
+++ b/tests/test_stripe_webhook.py
@@ -1,0 +1,123 @@
+"""
+POST /webhooks/stripe: signature verification and event application
+"""
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.models.subscription import Subscription
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+WEBHOOK_SECRET = "whsec_test_secret"
+WEBHOOK_PATH = "/api/v1/webhooks/stripe"
+
+
+@pytest.fixture
+def webhook_secret(monkeypatch):
+    monkeypatch.setattr(settings, "STRIPE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+
+
+def _sign(payload: bytes, secret: str = WEBHOOK_SECRET, timestamp: int = None) -> str:
+    timestamp = timestamp or int(time.time())
+    signed = f"{timestamp}.".encode() + payload
+    signature = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+    return f"t={timestamp},v1={signature}"
+
+
+def _event_payload(created=100, status="active") -> bytes:
+    return json.dumps({
+        "id": "evt_1",
+        "object": "event",
+        "type": "customer.subscription.updated",
+        "created": created,
+        "data": {"object": {
+            "id": "sub_1",
+            "customer": "cus_1",
+            "status": status,
+            "current_period_end": 1893456000,
+            "cancel_at_period_end": False,
+            "items": {"data": [{"price": {"id": "price_test"}}]},
+        }},
+    }).encode()
+
+
+async def _seed_subscription(session_maker, status="incomplete"):
+    async with session_maker() as session:
+        user = User(email="hook@example.com", password_hash="x", full_name="Hook User")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        session.add(Subscription(
+            user_id=user.id, stripe_customer_id="cus_1", status=status
+        ))
+        await session.commit()
+
+
+async def _row_status(session_maker) -> str:
+    async with session_maker() as session:
+        row = (await session.execute(select(Subscription))).scalar_one()
+        return row.status
+
+
+async def test_missing_signature_rejected(client_with_db, webhook_secret):
+    client, _ = client_with_db
+    response = await client.post(WEBHOOK_PATH, content=_event_payload())
+    assert response.status_code == 400
+
+
+async def test_invalid_signature_rejected(client_with_db, webhook_secret):
+    client, session_maker = client_with_db
+    await _seed_subscription(session_maker)
+    payload = _event_payload()
+    response = await client.post(
+        WEBHOOK_PATH,
+        content=payload,
+        headers={"stripe-signature": _sign(payload, secret="whsec_wrong")},
+    )
+    assert response.status_code == 400
+    assert await _row_status(session_maker) == "incomplete"
+
+
+async def test_valid_signature_applies_event(client_with_db, webhook_secret):
+    # No Authorization header — the webhook must not require JWT auth
+    client, session_maker = client_with_db
+    await _seed_subscription(session_maker)
+    payload = _event_payload(created=100, status="active")
+    response = await client.post(
+        WEBHOOK_PATH, content=payload, headers={"stripe-signature": _sign(payload)}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"received": True}
+    assert await _row_status(session_maker) == "active"
+
+
+async def test_replayed_event_is_harmless(client_with_db, webhook_secret):
+    client, session_maker = client_with_db
+    await _seed_subscription(session_maker)
+    payload = _event_payload(created=100, status="active")
+    for _ in range(2):
+        response = await client.post(
+            WEBHOOK_PATH, content=payload, headers={"stripe-signature": _sign(payload)}
+        )
+        assert response.status_code == 200
+    assert await _row_status(session_maker) == "active"
+
+
+async def test_stale_event_does_not_regress(client_with_db, webhook_secret):
+    client, session_maker = client_with_db
+    await _seed_subscription(session_maker)
+    newer = _event_payload(created=200, status="canceled")
+    await client.post(WEBHOOK_PATH, content=newer, headers={"stripe-signature": _sign(newer)})
+    older = _event_payload(created=150, status="active")
+    response = await client.post(
+        WEBHOOK_PATH, content=older, headers={"stripe-signature": _sign(older)}
+    )
+    assert response.status_code == 200
+    assert await _row_status(session_maker) == "canceled"


### PR DESCRIPTION
## Summary
Adds Stripe billing: a $499 one-time setup fee plus $99/month subscription gates LLM motion drafting and PDF export. Intake, gameplan chat, profile, and evidence tools remain free.

- **Gate**: `require_active_subscription` (402 `subscription_required`) on all `/llm/*` drafting routes, `documents` generate-pdf/-sync + `/{id}/download`, and `chat-pdf` generate-pdf + complete-workflow (the last two closed generation paths that bypassed the primary endpoints). Entitled statuses: `active`/`trialing`/`past_due` — a failed renewal never locks a user out mid-motion; revocation is delegated to Stripe dunning (dashboard set to cancel after retries).
- **Data**: new `subscriptions` table (one row per user), auto-created by the existing `create_all()` startup path. Webhook application is idempotent: absolute status snapshots + a `last_event_created` guard against replayed/out-of-order events.
- **Endpoints**: `POST /billing/checkout-session` (hosted Checkout, one-time + recurring line items), `POST /billing/portal-session`, `GET /billing/status`, `POST /billing/verify-session` (closes the pay-vs-webhook race on the success page), `POST /webhooks/stripe` (unauthenticated, signature-verified; stripe v15 returns non-dict StripeObjects so the verified raw payload is parsed as JSON).
- **Frontend**: `billing.ts` service + `isPaywallError`; PaywallModal (offer copy: 60-day money-back guarantee, 1-on-1 guided session); 402 branches in GuidedIntake (resume at final step post-subscribe) and MotionPreview; BillingSuccess (verify + status polling + scheduling link), BillingCanceled, Dashboard Subscribe/Manage-billing button. Small extractions (`intakeNavigation.ts`, `downloadBlob.ts`) keep both touched components under the 300-line cap.
- **Config**: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID` ($99/mo), `STRIPE_SETUP_PRICE_ID` ($499), `FRONTEND_URL`; checkout 503s unless both prices are configured. `BILLING_ENABLED` is read per-request (mirrors `RATE_LIMIT_ENABLED`) and forced off in the test suite.

## Test plan
- TDD throughout: backend 590 passed / 3 xfailed (46 billing-specific: model, config, gate matrix, service idempotency, endpoints, webhook with real HMAC signatures); frontend 43 suites / 280 passed; production build compiles.
- Live test-mode E2E (2026-07-18): 402 pre-pay → Checkout session with $499+$99 line items → test-card payment ($598.00 first invoice, paid) → webhook unlock in ~1s → drafting 200 / portal OK → cancel → webhook re-lock in ~1s → 402.

Go-live steps (live keys/prices into Secret Manager, prod webhook registration, live portal + dunning config) are tracked as S15 in tasks/todo.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)